### PR TITLE
feat: make buildRecipes public on JsonRecipeProvider

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/datagen/recipe/JsonRecipeProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/recipe/JsonRecipeProvider.java
@@ -228,5 +228,5 @@ public abstract class JsonRecipeProvider implements DataProvider {
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    abstract void buildRecipes(BiConsumer<ResourceLocation, JsonObject> recipeConsumer);
+    public abstract void buildRecipes(BiConsumer<ResourceLocation, JsonObject> recipeConsumer);
 }


### PR DESCRIPTION
Make sure recipe providers can be made outside package