### PR TITLE
Fixes #189 and #188 caused by deprecated dropContents function

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlock.java
@@ -156,7 +156,6 @@ public class CalcinationOvenBlock extends Block implements EntityBlock {
                 for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
                     Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
                 }
-                //Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(0));
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlock.java
@@ -153,7 +153,10 @@ public class CalcinationOvenBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pState.getValue(HALF) == DoubleBlockHalf.LOWER && pLevel.getBlockEntity(pPos) instanceof CalcinationOvenBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.storageBehaviour.inventory));
+                for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
+                }
+                //Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(0));
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionVatBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionVatBlock.java
@@ -116,7 +116,9 @@ public class DigestionVatBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof DigestionVatBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.storageBehaviour.inventory));
+                for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerBlock.java
@@ -152,7 +152,9 @@ public class DistillerBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pState.getValue(HALF) == DoubleBlockHalf.LOWER && pLevel.getBlockEntity(pPos) instanceof DistillerBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.storageBehaviour.inventory));
+                for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationVatBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationVatBlock.java
@@ -116,7 +116,9 @@ public class FermentationVatBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof FermentationVatBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.storageBehaviour.inventory));
+                for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlock.java
@@ -183,7 +183,9 @@ public class IncubatorBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pState.getValue(HALF) == DoubleBlockHalf.LOWER && pLevel.getBlockEntity(pPos) instanceof IncubatorBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.outputInventory));
+                for (int i = 0; i < blockEntity.outputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.outputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlock.java
@@ -38,7 +38,9 @@ public class IncubatorMercuryVesselBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof IncubatorMercuryVesselBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inputInventory));
+                for (int i = 0; i < blockEntity.inputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlock.java
@@ -39,7 +39,9 @@ public class IncubatorSaltVesselBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof IncubatorSaltVesselBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inputInventory));
+                for (int i = 0; i < blockEntity.inputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlock.java
@@ -38,7 +38,9 @@ public class IncubatorSulfurVesselBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof IncubatorSulfurVesselBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inputInventory));
+                for (int i = 0; i < blockEntity.inputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCauldronBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCauldronBlock.java
@@ -155,7 +155,9 @@ public class LiquefactionCauldronBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pState.getValue(HALF) == DoubleBlockHalf.LOWER && pLevel.getBlockEntity(pPos) instanceof LiquefactionCauldronBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.storageBehaviour.inventory));
+                for (int i = 0; i < blockEntity.storageBehaviour.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.storageBehaviour.inventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
@@ -106,7 +106,7 @@ public class PyromanticBrazierBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof PyromanticBrazierBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inventory));
+                Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inventory.getStackInSlot(0));
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
@@ -106,7 +106,9 @@ public class PyromanticBrazierBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof PyromanticBrazierBlockEntity blockEntity) {
-                Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inventory.getStackInSlot(0));
+                for (int i = 0; i < blockEntity.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlock.java
@@ -50,11 +50,12 @@ public class ReformationResultPedestalBlock extends Block implements EntityBlock
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof ReformationResultPedestalBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.outputInventory));
+                for (int i = 0; i < blockEntity.outputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.outputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlock.java
@@ -53,7 +53,9 @@ public class ReformationSourcePedestalBlock extends Block implements EntityBlock
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof ReformationSourcePedestalBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inputInventory));
+                for (int i = 0; i < blockEntity.inputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inputInventory.getStackInSlot(i));
+                }
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlock.java
@@ -53,8 +53,9 @@ public class ReformationTargetPedestalBlock extends Block implements EntityBlock
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof ReformationTargetPedestalBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inputInventory));
-            }
+                for (int i = 0; i < blockEntity.inputInventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inputInventory.getStackInSlot(i));
+                }            }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlock.java
@@ -73,7 +73,10 @@ public class SalAmmoniacAccumulatorBlock extends Block implements EntityBlock {
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (!pState.is(pNewState.getBlock())) {
             if (pLevel.getBlockEntity(pPos) instanceof SalAmmoniacAccumulatorBlockEntity blockEntity) {
-                Containers.dropContents(pLevel, pPos, new RecipeWrapper(blockEntity.inventory));
+                for (int i = 0; i < blockEntity.inventory.getSlots(); i++) {
+                    Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inventory.getStackInSlot(i));
+                }
+                //Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), blockEntity.inventory.getStackInSlot(0));
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);


### PR DESCRIPTION
Fixes #189 and #188. 
Refactoring dropContents to dropItemStack in PyromanticBrazierBlock, IncubatorBlock, IncubatorSaltVesselBlock, DigestionVatBlock, IncubatorSulfurVesselBlock, and IncubatorMercuryVesselBlock