### PR TITLE
feat: add remaining game tests for brazier, oven, and cauldron

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
@@ -184,11 +184,6 @@ public class PyromanticBrazierBlockEntity extends BlockEntity {
         }
 
         @Override
-        public boolean isValid(int index, ItemResource resource) {
-            return this.isItemValid(index, resource.toStack(1));
-        }
-
-        @Override
         protected void onContentTypeChanged(int slot, ItemStack oldStack, ItemStack newStack) {
             //we also need to network sync our BE, because if the content type changes then the interaction behaviour client side changes
             PyromanticBrazierBlockEntity.this.sendBlockUpdated();

--- a/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
@@ -123,7 +123,7 @@ public class CalcinationOvenGameTests {
         });
 
         helper.succeedWhen(() -> {
-            helper.assertItemEntityPresent(Items.COBBLESTONE, OVEN_LOWER_POS, 2.0);
+            helper.assertItemCount(Items.COBBLESTONE, OVEN_LOWER_POS, 2.0, 3);
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
@@ -123,7 +123,7 @@ public class CalcinationOvenGameTests {
         });
 
         helper.succeedWhen(() -> {
-            helper.assertItemCount(Items.COBBLESTONE, OVEN_LOWER_POS, 2.0, 3);
+            helper.assertItemEntityCountIs(Items.COBBLESTONE, OVEN_LOWER_POS, 2.0, 3);
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/CalcinationOvenGameTests.java
@@ -107,6 +107,26 @@ public class CalcinationOvenGameTests {
         });
     }
 
+    /**
+     * Tests that items in the oven's inventory are dropped when the block is broken.
+     */
+    public static void dropsItemsWhenBroken(GameTestHelper helper) {
+        placeOven(helper);
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(OVEN_LOWER_POS, CalcinationOvenBlockEntity.class);
+            blockEntity.storageBehaviour.inputInventory.setStackInSlot(0, new ItemStack(Items.COBBLESTONE, 3));
+        });
+
+        helper.runAfterDelay(2, () -> {
+            helper.destroyBlock(OVEN_LOWER_POS);
+        });
+
+        helper.succeedWhen(() -> {
+            helper.assertItemEntityPresent(Items.COBBLESTONE, OVEN_LOWER_POS, 2.0);
+        });
+    }
+
     // --- Item Handling ---
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
@@ -77,6 +77,12 @@ public class GameTestRegistry {
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LC_PROCESSING_REQUIRES_SOLVENT =
             TEST_FUNCTIONS.register("lc_processing_requires_solvent", () -> LiquefactionCauldronGameTests::processingRequiresSolvent);
 
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LC_DROPS_ITEMS_WHEN_BROKEN =
+            TEST_FUNCTIONS.register("lc_drops_items_when_broken", () -> LiquefactionCauldronGameTests::dropsItemsWhenBroken);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LC_EXTRACT_SOLVENT_FLUID =
+            TEST_FUNCTIONS.register("lc_extract_solvent_fluid", () -> LiquefactionCauldronGameTests::extractSolventFluid);
+
     // --- Calcination Oven ---
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> OVEN_PLACEMENT =
@@ -112,6 +118,9 @@ public class GameTestRegistry {
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> OVEN_STOPS_WITHOUT_INPUT =
             TEST_FUNCTIONS.register("calcination_oven_stops_without_input", () -> CalcinationOvenGameTests::processingStopsWhenInputEmpty);
 
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> OVEN_DROPS_ITEMS_WHEN_BROKEN =
+            TEST_FUNCTIONS.register("calcination_oven_drops_items_when_broken", () -> CalcinationOvenGameTests::dropsItemsWhenBroken);
+
     // --- Pyromantic Brazier ---
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_PLACEMENT =
@@ -140,6 +149,12 @@ public class GameTestRegistry {
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_STOPS_HEAT_NO_FUEL =
             TEST_FUNCTIONS.register("pyromantic_brazier_stops_heat_no_fuel", () -> PyromanticBrazierGameTests::stopsProvidingHeatWhenFuelRunsOut);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_REMOVE_FUEL =
+            TEST_FUNCTIONS.register("pyromantic_brazier_remove_fuel", () -> PyromanticBrazierGameTests::removeFuelViaEmptyHand);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_DROPS_ITEMS_WHEN_BROKEN =
+            TEST_FUNCTIONS.register("pyromantic_brazier_drops_items_when_broken", () -> PyromanticBrazierGameTests::dropsItemsWhenBroken);
 
     public static void onRegisterGameTests(RegisterGameTestsEvent event) {
         registerMercuryCatalystTests(event);
@@ -175,6 +190,8 @@ public class GameTestRegistry {
         registerTest(event, LC_PROCESSING_STOPS_WHEN_HEAT_REMOVED, environment, structure, 300, 0);
         registerTest(event, LC_PROCESSING_REQUIRES_INPUT, environment, structure, 100, 0);
         registerTest(event, LC_PROCESSING_REQUIRES_SOLVENT, environment, structure, 100, 0);
+        registerTest(event, LC_DROPS_ITEMS_WHEN_BROKEN, environment, structure, 40, 0);
+        registerTest(event, LC_EXTRACT_SOLVENT_FLUID, environment, structure, 40, 0);
     }
 
     private static void registerCalcinationOvenTests(RegisterGameTestsEvent event) {
@@ -192,6 +209,7 @@ public class GameTestRegistry {
         registerTest(event, OVEN_INPUT_CONSUMED_OUTPUT_PRODUCED, environment, structure, 300, 0);
         registerTest(event, OVEN_STOPS_WITHOUT_HEAT, environment, structure, 400, 0);
         registerTest(event, OVEN_STOPS_WITHOUT_INPUT, environment, structure, 300, 0);
+        registerTest(event, OVEN_DROPS_ITEMS_WHEN_BROKEN, environment, structure, 40, 0);
     }
 
     private static void registerPyromanticBrazierTests(RegisterGameTestsEvent event) {
@@ -207,6 +225,8 @@ public class GameTestRegistry {
         registerTest(event, BRAZIER_HEAT_LIQUEFACTION_CAULDRON, environment, structure, 100, 0);
         registerTest(event, BRAZIER_HEAT_DISTILLER, environment, structure, 100, 0);
         registerTest(event, BRAZIER_STOPS_HEAT_NO_FUEL, environment, structure, 300, 0);
+        registerTest(event, BRAZIER_REMOVE_FUEL, environment, structure, 40, 0);
+        registerTest(event, BRAZIER_DROPS_ITEMS_WHEN_BROKEN, environment, structure, 40, 0);
     }
 
     private static void registerTest(

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
@@ -159,7 +159,7 @@ public class LiquefactionCauldronGameTests {
         });
 
         helper.succeedWhen(() -> {
-            helper.assertItemEntityPresent(Items.BONE, CAULDRON_LOWER_POS, 2.0);
+            helper.assertItemCount(Items.BONE, CAULDRON_LOWER_POS, 2.0, 3);
         });
     }
 
@@ -239,8 +239,8 @@ public class LiquefactionCauldronGameTests {
         helper.succeedWhen(() -> {
             var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
             helper.assertTrue(
-                    cauldron.storageBehaviour.solventTank.getFluidAmount() < 1000,
-                    "Solvent tank should have less fluid after bucket extraction"
+                    cauldron.storageBehaviour.solventTank.getFluidAmount() == 0,
+                    "Solvent tank should be empty after bucket extraction"
             );
         });
     }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
@@ -159,7 +159,7 @@ public class LiquefactionCauldronGameTests {
         });
 
         helper.succeedWhen(() -> {
-            helper.assertItemCount(Items.BONE, CAULDRON_LOWER_POS, 2.0, 3);
+            helper.assertItemEntityCountIs(Items.BONE, CAULDRON_LOWER_POS, 2.0, 3);
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
@@ -15,6 +15,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -142,6 +143,26 @@ public class LiquefactionCauldronGameTests {
         });
     }
 
+    /**
+     * Tests that items in the cauldron's inventory are dropped when the block is broken.
+     */
+    public static void dropsItemsWhenBroken(GameTestHelper helper) {
+        placeCauldron(helper);
+
+        helper.runAfterDelay(1, () -> {
+            var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
+            cauldron.storageBehaviour.inputInventory.setStackInSlot(0, new ItemStack(Items.BONE, 3));
+        });
+
+        helper.runAfterDelay(2, () -> {
+            helper.destroyBlock(CAULDRON_LOWER_POS);
+        });
+
+        helper.succeedWhen(() -> {
+            helper.assertItemEntityPresent(Items.BONE, CAULDRON_LOWER_POS, 2.0);
+        });
+    }
+
     // ==================== Item & Fluid Handling ====================
 
     /**
@@ -187,6 +208,40 @@ public class LiquefactionCauldronGameTests {
                     "Solvent tank should contain 500mb of sal ammoniac"
             );
             helper.succeed();
+        });
+    }
+
+    /**
+     * Tests that solvent fluid can be extracted from the cauldron using a bucket.
+     * The OneTankFluidHandlerBehaviour allows bucket interaction via FluidUtil.
+     */
+    public static void extractSolventFluid(GameTestHelper helper) {
+        placeCauldron(helper);
+
+        helper.runAfterDelay(1, () -> {
+            var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
+            cauldron.storageBehaviour.solventTank.fill(
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+            );
+            helper.assertTrue(
+                    cauldron.storageBehaviour.solventTank.getFluidAmount() == 1000,
+                    "Solvent tank should contain 1000mb before extraction"
+            );
+        });
+
+        helper.runAfterDelay(2, () -> {
+            // Simulate right-click with a bucket to extract fluid
+            var player = helper.createMockPlayer(GameType.SURVIVAL);
+            player.getInventory().setItem(0, new ItemStack(Items.BUCKET));
+            helper.useBlock(player, CAULDRON_LOWER_POS);
+        });
+
+        helper.succeedWhen(() -> {
+            var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
+            helper.assertTrue(
+                    cauldron.storageBehaviour.solventTank.getFluidAmount() < 1000,
+                    "Solvent tank should have less fluid after bucket extraction"
+            );
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
@@ -231,9 +231,9 @@ public class LiquefactionCauldronGameTests {
 
         helper.runAfterDelay(2, () -> {
             // Simulate right-click with a bucket to extract fluid
-            var player = helper.createMockPlayer(GameType.SURVIVAL);
+            var player = helper.makeMockPlayer(GameType.SURVIVAL);
             player.getInventory().setItem(0, new ItemStack(Items.BUCKET));
-            helper.useBlock(player, CAULDRON_LOWER_POS);
+            helper.useBlock( helper.relativePos(CAULDRON_LOWER_POS), player);
         });
 
         helper.succeedWhen(() -> {

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -10,8 +10,10 @@ import com.klikli_dev.theurgy.registry.CapabilityRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
@@ -113,6 +115,57 @@ public class PyromanticBrazierGameTests {
                     blockEntity.inventory.getStackInSlot(0).isEmpty(),
                     "Coal should be consumed after burning"
             );
+        });
+    }
+
+    /**
+     * Tests that fuel can be removed by right-clicking the brazier with an empty hand.
+     * The block's useItemOn handler ejects the fuel into the player's inventory.
+     */
+    public static void removeFuelViaEmptyHand(GameTestHelper helper) {
+        helper.setBlock(BRAZIER_POS, BlockRegistry.PYROMANTIC_BRAZIER.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            blockEntity.inventory.setStackInSlot(0, new ItemStack(Items.COAL, 1));
+            helper.assertTrue(
+                    !blockEntity.inventory.getStackInSlot(0).isEmpty(),
+                    "Brazier should contain coal before removal"
+            );
+        });
+
+        helper.runAfterDelay(2, () -> {
+            // Simulate right-click with empty hand (survival mode player)
+            helper.useBlock(BRAZIER_POS);
+        });
+
+        helper.succeedWhen(() -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            helper.assertTrue(
+                    blockEntity.inventory.getStackInSlot(0).isEmpty(),
+                    "Brazier inventory should be empty after removing fuel with empty hand"
+            );
+        });
+    }
+
+    /**
+     * Tests that fuel items are dropped as entities when the brazier is broken.
+     */
+    public static void dropsItemsWhenBroken(GameTestHelper helper) {
+        helper.setBlock(BRAZIER_POS, BlockRegistry.PYROMANTIC_BRAZIER.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            blockEntity.inventory.setStackInSlot(0, new ItemStack(Items.COAL, 3));
+        });
+
+        helper.runAfterDelay(2, () -> {
+            helper.destroyBlock(BRAZIER_POS);
+        });
+
+        helper.succeedWhen(() -> {
+            // Verify coal items were dropped at the brazier position
+            helper.assertItemEntityPresent(Items.COAL, BRAZIER_POS, 2.0);
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -164,8 +164,8 @@ public class PyromanticBrazierGameTests {
         });
 
         helper.succeedWhen(() -> {
-            // Verify coal items were dropped at the brazier position
-            helper.assertItemEntityPresent(Items.COAL, BRAZIER_POS, 2.0);
+            // Verify exact count of coal items dropped
+            helper.assertItemCount(Items.COAL, BRAZIER_POS, 2.0, 3);
         });
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -165,7 +165,7 @@ public class PyromanticBrazierGameTests {
 
         helper.succeedWhen(() -> {
             // Verify exact count of coal items dropped
-            helper.assertItemCount(Items.COAL, BRAZIER_POS, 2.0, 3);
+            helper.assertItemEntityCountIs(Items.COAL, BRAZIER_POS, 2.0, 3);
         });
     }
 


### PR DESCRIPTION
## Summary

Adds the remaining unchecked game tests from #293 for Pyromantic Brazier, Calcination Oven, and Liquefaction Cauldron.

### New Tests

**Pyromantic Brazier (2 tests)**
- `removeFuelViaEmptyHand` — Verifies fuel is ejected when right-clicking with empty hand
- `dropsItemsWhenBroken` — Verifies fuel items drop as entities when block is broken

**Calcination Oven (1 test)**
- `dropsItemsWhenBroken` — Verifies inventory items drop when block is broken

**Liquefaction Cauldron (2 tests)**
- `dropsItemsWhenBroken` — Verifies inventory items drop when block is broken
- `extractSolventFluid` — Verifies solvent fluid can be extracted via bucket right-click

Refs #293 (does not close — many blocks still need test coverage: Distiller, Incubator, Fermentation Vat, Digestion Vat, Sal Ammoniac Accumulator/Tank, Caloric Flux Emitter, Sulfuric Flux Emitter, pedestals, logistics, ores)