### PR TITLE
fix: prevent instant recipe completion in vats after Create contraption movement

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
@@ -68,8 +68,9 @@ public abstract class CraftingBehaviour<W extends RecipeInput, R extends Recipe<
 
     public void loadAdditional(ValueInput input) {
         this.progress = input.getShortOr("progress", (short) 0);
+        this.totalTime = input.getShortOr("totalTime", (short) 0);
         //totalTime is not saved in older versions, so we recalculate from recipe if we have progress
-        if (this.progress > 0) {
+        if (this.progress > 0 && this.totalTime == 0) {
             this.totalTime = this.getTotalTime();
         }
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
@@ -63,10 +63,15 @@ public abstract class CraftingBehaviour<W extends RecipeInput, R extends Recipe<
 
     public void saveAdditional(ValueOutput output) {
         output.putShort("progress", (short) this.progress);
+        output.putShort("totalTime", (short) this.totalTime);
     }
 
     public void loadAdditional(ValueInput input) {
         this.progress = input.getShortOr("progress", (short) 0);
+        //totalTime is not saved in older versions, so we recalculate from recipe if we have progress
+        if (this.progress > 0) {
+            this.totalTime = this.getTotalTime();
+        }
     }
 
     public void applyImplicitComponents(DataComponentGetter pComponentGetter) {


### PR DESCRIPTION
## Summary
- Save `totalTime` to NBT in `CraftingBehaviour.saveAdditional()`
- Recalculate `totalTime` from the recipe on load when `progress > 0`

## Problem
`CraftingBehaviour` persisted `progress` but never `totalTime`. When a Create mod contraption moved a digestion or fermentation vat and placed it back, the block entity was deserialized with the saved `progress` (e.g., 15) but `totalTime` defaulted to 0. On the next tick, `progress++` made it 16, and `16 >= 0` caused the recipe to complete instantly.

## Fix
In `loadAdditional()`, when `progress > 0`, recalculate `totalTime` from the current recipe via `getTotalTime()`. This ensures the timer is always valid after deserialization, and also handles the case where a recipe's duration may have changed between saves.

Fixes #258