### PR TITLE
fix: prevent instant recipe completion in vats after Create contraption movement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## General
+- CREATE CONVENTIONAL COMMITS FOR EACH ATOMIC CHANGE.
+- CREATE A BRANCH FOR EACH FEATURE OR FIX YOU WORK ON, then create a pull request when ready.
+- Read `gradle.properties` to find the current minecraft version used.
+
+## Minecraft source lookups
+- Prefer the `minecraft-dev` MCP tools for all vanilla lookups, diffs, and signature checks.
+- Always use **Mojmaps** when querying Minecraft code with `minecraft-dev`.
+- Use `minecraft-dev` version comparison and source lookup before editing code.
+
+## Mapping and version rules
+- If anything requests a mapping, use mojmaps.
+
+## Build and validation
+- Use the Gradle wrapper from repo root.
+- Common checks:
+  - `./gradlew.bat compileJava`
+  - `./gradlew.bat runClient`
+  - `./gradlew.bat runServer`
+  - `./gradlew.bat runData`
+- Keep changes minimal and validate edited code before finishing.
+
+## Repo conventions
+- Follow the REUSE standard for SPDX license file headers.
+- Generated resources live in `src/generated/resources`; main assets/data live in `src/main/resources`.
+- Several integrations are intentionally excluded in `build.gradle`; do not re-enable them.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -72,3 +72,9 @@ path = "CHANGELOG.md"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 klikli-dev"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = "AGENTS.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 klikli-dev"
+SPDX-License-Identifier = "CC0-1.0"

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
@@ -62,11 +62,18 @@ public abstract class CraftingBehaviour<W extends RecipeInput, R extends Recipe<
 
     public void saveAdditional(CompoundTag pTag, HolderLookup.Provider pRegistries) {
         pTag.putShort("progress", (short) this.progress);
+        pTag.putShort("totalTime", (short) this.totalTime);
     }
 
     public void loadAdditional(CompoundTag pTag, HolderLookup.Provider pRegistries) {
         if (pTag.contains("progress"))
             this.progress = pTag.getShort("progress");
+        if (pTag.contains("totalTime"))
+            this.totalTime = pTag.getShort("totalTime");
+        //totalTime is not saved in older versions, so we recalculate from recipe if we have progress
+        if (this.progress > 0 && this.totalTime == 0) {
+            this.totalTime = this.getTotalTime();
+        }
     }
 
     public void applyImplicitComponents(BlockEntity.DataComponentInput pComponentInput) {


### PR DESCRIPTION
## Summary
- Save `totalTime` to NBT in `CraftingBehaviour.saveAdditional()`
- Recalculate `totalTime` from the recipe on load when `progress > 0`

## Problem
`CraftingBehaviour` persisted `progress` but never `totalTime`. When a Create mod contraption moved a digestion or fermentation vat and placed it back, the block entity was deserialized with the saved `progress` (e.g., 15) but `totalTime` defaulted to 0. On the next tick, `progress++` made it 16, and `16 >= 0` caused the recipe to complete instantly.

## Fix
In `loadAdditional()`, when `progress > 0`, recalculate `totalTime` from the current recipe via `getTotalTime()`. This ensures the timer is always valid after deserialization, and also handles the case where a recipe's duration may have changed between saves.

Fixes #258