### PR TITLE
feat: add in-world mercury catalyst HUD

### DIFF
--- a/src/generated/resources/assets/theurgy/lang/en_us.json
+++ b/src/generated/resources/assets/theurgy/lang/en_us.json
@@ -2673,6 +2673,7 @@
   "theurgy.behaviour.selection.summary.sulfuric_flux_emitter.no_selection": "Sulfuric Flux Emitter has no linked pedestals.",
   "theurgy.behaviour.selection.summary.sulfuric_flux_emitter.no_sources": "Sulfuric Flux Emitter has no linked source pedestals.",
   "theurgy.behaviour.selection.summary.sulfuric_flux_emitter.no_target": "Sulfuric Flux Emitter has no linked target pedestal.",
+  "theurgy.configuration.enableInWorldHUD": "Enable In-World HUD",
   "theurgy.configuration.enableItemHUD": "Enable Item HUD",
   "theurgy.configuration.hudScale": "HUD Scale",
   "theurgy.configuration.misc": "Misc Settings",

--- a/src/main/java/com/klikli_dev/theurgy/Theurgy.java
+++ b/src/main/java/com/klikli_dev/theurgy/Theurgy.java
@@ -28,6 +28,10 @@ import com.klikli_dev.theurgy.content.item.salt.AlchemicalSaltItem;
 import com.klikli_dev.theurgy.content.item.sulfur.AlchemicalSulfurItem;
 import com.klikli_dev.theurgy.content.item.wire.WireItem;
 import com.klikli_dev.theurgy.content.render.*;
+import com.klikli_dev.theurgy.content.render.inworldhud.ClientItemStacksTooltip;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUD;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDRegistry;
+import com.klikli_dev.theurgy.content.render.inworldhud.ItemStacksTooltip;
 import com.klikli_dev.theurgy.content.render.itemhud.ItemHUD;
 import com.klikli_dev.theurgy.content.render.outliner.Outliner;
 import com.klikli_dev.theurgy.util.ScrollHelper;
@@ -144,6 +148,7 @@ public class Theurgy {
             modEventBus.addListener(Client::onRegisterBlockColors);
             modEventBus.addListener(Client::onRegisterGuiOverlays);
             modEventBus.addListener(Client::onRegisterMenuScreens);
+            modEventBus.addListener(Client::onRegisterClientTooltipComponentFactories);
             modEventBus.addListener(BlockOverlays::onTextureAtlasStitched);
             modEventBus.addListener(KeyMappingsRegistry::onRegisterKeyMappings);
             modEventBus.addListener(Client::onRegisterItemProperties);
@@ -166,6 +171,7 @@ public class Theurgy {
     }
 
     public void onCommonSetup(FMLCommonSetupEvent event) {
+        event.enqueueWork(InWorldHUDRegistry::registerDefaults);
         PageLoaders.onCommonSetup(event);
 
         LOGGER.info("Common setup complete.");
@@ -234,6 +240,7 @@ public class Theurgy {
 
             Player player = Minecraft.getInstance().player;
 
+            InWorldHUD.get().tick(Minecraft.getInstance());
             Outliner.get().tick();
             BlockRegistry.CALORIC_FLUX_EMITTER.get().selectionBehaviour().tick(player);
             BlockRegistry.SULFURIC_FLUX_EMITTER.get().selectionBehaviour().tick(player);
@@ -321,7 +328,12 @@ public class Theurgy {
         }
 
         public static void onRegisterGuiOverlays(RegisterGuiLayersEvent event) {
+            event.registerAbove(VanillaGuiLayers.HOTBAR, Theurgy.loc("in_world_hud"), InWorldHUD.get());
             event.registerAbove(VanillaGuiLayers.HOTBAR, Theurgy.loc("item_hud"), ItemHUD.get());
+        }
+
+        public static void onRegisterClientTooltipComponentFactories(RegisterClientTooltipComponentFactoriesEvent event) {
+            event.register(ItemStacksTooltip.class, ClientItemStacksTooltip::new);
         }
 
         public static void onRegisterMenuScreens(RegisterMenuScreensEvent event) {

--- a/src/main/java/com/klikli_dev/theurgy/config/ClientConfig.java
+++ b/src/main/java/com/klikli_dev/theurgy/config/ClientConfig.java
@@ -29,6 +29,7 @@ public class ClientConfig {
 
         public final BooleanValue renderSulfurSourceItem;
         public final BooleanValue enableItemHUD;
+        public final BooleanValue enableInWorldHUD;
         public final ModConfigSpec.DoubleValue itemHUDScale;
 
         public Rendering(ModConfigSpec.Builder builder) {
@@ -42,6 +43,10 @@ public class ClientConfig {
             this.enableItemHUD = builder
                     .comment("True to enable the item HUD, false to disable it.")
                     .define("enableItemHUD", true);
+
+            this.enableInWorldHUD = builder
+                    .comment("True to enable the in-world HUD when looking at supported machine blocks, false to disable it.")
+                    .define("enableInWorldHUD", true);
 
             this.itemHUDScale = builder
                     .comment("The scale of the Item HUD text (e.g. for the mercurial wand).")

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/ClientItemStacksTooltip.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/ClientItemStacksTooltip.java
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+public class ClientItemStacksTooltip implements ClientTooltipComponent {
+
+    private static final int SLOT_SIZE = 18;
+    private static final int HEIGHT = 20;
+
+    private final List<ItemStack> items;
+
+    public ClientItemStacksTooltip(ItemStacksTooltip tooltip) {
+        this.items = tooltip.items();
+    }
+
+    @Override
+    public int getHeight(Font font) {
+        return this.items.isEmpty() ? 0 : HEIGHT;
+    }
+
+    @Override
+    public int getWidth(Font font) {
+        return this.items.size() * SLOT_SIZE;
+    }
+
+    @Override
+    public void extractImage(Font font, int x, int y, int width, int height, GuiGraphicsExtractor guiGraphics) {
+        for (int i = 0; i < this.items.size(); i++) {
+            ItemStack stack = this.items.get(i);
+            int itemX = x + i * SLOT_SIZE;
+            guiGraphics.item(stack, itemX, y + 1);
+            guiGraphics.itemDecorations(font, stack, itemX, y + 1);
+        }
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUD.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUD.java
@@ -52,7 +52,7 @@ public class InWorldHUD implements GuiLayer {
         }
 
         if (!lookedAtPos.equals(this.currentPos)) {
-            this.currentPos = lookedAtPos.immutable();
+            this.currentPos = lookedAtPos;
             this.serverSnapshot = InWorldHUDSnapshot.EMPTY;
             this.nextRequestTick = 0;
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUD.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUD.java
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import com.klikli_dev.theurgy.config.ClientConfig;
+import com.klikli_dev.theurgy.network.Networking;
+import com.klikli_dev.theurgy.network.messages.MessageRequestInWorldHUD;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.neoforged.neoforge.client.ClientHooks;
+import net.neoforged.neoforge.client.gui.GuiLayer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InWorldHUD implements GuiLayer {
+
+    private static final InWorldHUD INSTANCE = new InWorldHUD();
+    private static final int REQUEST_INTERVAL_TICKS = 5;
+    private static final int TOP_PADDING = 4;
+
+    private @Nullable BlockPos currentPos;
+    private InWorldHUDSnapshot serverSnapshot = InWorldHUDSnapshot.EMPTY;
+    private int nextRequestTick;
+
+    public static InWorldHUD get() {
+        return INSTANCE;
+    }
+
+    public void tick(Minecraft minecraft) {
+        if (!this.canRun(minecraft)) {
+            this.clear();
+            return;
+        }
+
+        BlockPos lookedAtPos = this.getLookedAtPos(minecraft.hitResult);
+        if (lookedAtPos == null || !InWorldHUDRegistry.hasProviders(minecraft.level, lookedAtPos)) {
+            this.clear();
+            return;
+        }
+
+        if (!lookedAtPos.equals(this.currentPos)) {
+            this.currentPos = lookedAtPos.immutable();
+            this.serverSnapshot = InWorldHUDSnapshot.EMPTY;
+            this.nextRequestTick = 0;
+        }
+
+        if (minecraft.player.tickCount >= this.nextRequestTick) {
+            Networking.sendToServer(new MessageRequestInWorldHUD(this.currentPos));
+            this.nextRequestTick = minecraft.player.tickCount + REQUEST_INTERVAL_TICKS;
+        }
+    }
+
+    public void acceptServerSnapshot(BlockPos pos, InWorldHUDSnapshot snapshot) {
+        if (this.currentPos != null && this.currentPos.equals(pos)) {
+            this.serverSnapshot = snapshot;
+        }
+    }
+
+    @Override
+    public void render(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (!this.canRun(minecraft) || this.currentPos == null || minecraft.level == null) {
+            return;
+        }
+
+        BlockPos lookedAtPos = this.getLookedAtPos(minecraft.hitResult);
+        if (!this.currentPos.equals(lookedAtPos)) {
+            return;
+        }
+
+        InWorldHUDBuilder builder = new InWorldHUDBuilder();
+        builder.append(InWorldHUDRegistry.gatherClientSnapshot(minecraft.level, this.currentPos));
+        builder.append(this.serverSnapshot);
+
+        InWorldHUDSnapshot snapshot = builder.build();
+        if (snapshot.isEmpty()) {
+            return;
+        }
+
+        List<Either<FormattedText, TooltipComponent>> elements = new ArrayList<>();
+        snapshot.title().ifPresent(title -> elements.add(Either.left(title)));
+        snapshot.lines().forEach(line -> elements.add(Either.left(line)));
+        if (!snapshot.items().isEmpty()) {
+            elements.add(Either.right(new ItemStacksTooltip(snapshot.items())));
+        }
+
+        List<ClientTooltipComponent> components = ClientHooks.gatherTooltipComponentsFromElements(
+                ItemStack.EMPTY,
+                elements,
+                guiGraphics.guiWidth() / 2,
+                guiGraphics.guiWidth(),
+                guiGraphics.guiHeight(),
+                minecraft.font
+        );
+
+        guiGraphics.tooltip(minecraft.font, components, guiGraphics.guiWidth() / 2, TOP_PADDING, TopCenterTooltipPositioner.INSTANCE, null);
+    }
+
+    private boolean canRun(Minecraft minecraft) {
+        return !minecraft.options.hideGui
+                && minecraft.player != null
+                && minecraft.level != null
+                && !minecraft.player.isSpectator()
+                && ClientConfig.get().rendering.enableInWorldHUD.get();
+    }
+
+    private void clear() {
+        this.currentPos = null;
+        this.serverSnapshot = InWorldHUDSnapshot.EMPTY;
+        this.nextRequestTick = 0;
+    }
+
+    private @Nullable BlockPos getLookedAtPos(@Nullable HitResult hitResult) {
+        if (hitResult instanceof BlockHitResult blockHitResult && hitResult.getType() == HitResult.Type.BLOCK) {
+            return blockHitResult.getBlockPos();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDBuilder.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDBuilder.java
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class InWorldHUDBuilder {
+
+    private @Nullable Component title;
+    private final List<Component> lines = new ArrayList<>();
+    private final List<ItemStack> items = new ArrayList<>();
+
+    public void setTitleIfAbsent(Component title) {
+        if (this.title == null) {
+            this.title = title;
+        }
+    }
+
+    public void addLine(Component line) {
+        if (!this.lines.contains(line)) {
+            this.lines.add(line);
+        }
+    }
+
+    public void addItem(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        this.items.add(stack.copy());
+    }
+
+    public void append(InWorldHUDSnapshot snapshot) {
+        snapshot.title().ifPresent(this::setTitleIfAbsent);
+        snapshot.lines().forEach(this::addLine);
+        snapshot.items().forEach(this::addItem);
+    }
+
+    public InWorldHUDSnapshot build() {
+        if (this.title == null && this.lines.isEmpty() && this.items.isEmpty()) {
+            return InWorldHUDSnapshot.EMPTY;
+        }
+        return new InWorldHUDSnapshot(Optional.ofNullable(this.title), this.lines, this.items);
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDProvider.java
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public interface InWorldHUDProvider {
+
+    boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
+
+    default void appendClientData(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+    }
+
+    default void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.ItemStorageInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryCatalystInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxStorageInWorldHUDProvider;
+import com.klikli_dev.theurgy.registry.BlockRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InWorldHUDRegistry {
+
+    private static final Map<Block, List<InWorldHUDProvider>> BLOCK_PROVIDERS = new HashMap<>();
+    private static final List<InWorldHUDProvider> GENERIC_PROVIDERS = new ArrayList<>();
+
+    private static boolean defaultsRegistered;
+
+    public static void registerDefaults() {
+        if (defaultsRegistered) {
+            return;
+        }
+
+        registerBlockProvider(BlockRegistry.MERCURY_CATALYST.get(), new MercuryCatalystInWorldHUDProvider());
+        registerGenericProvider(new MercuryFluxStorageInWorldHUDProvider());
+        registerGenericProvider(new ItemStorageInWorldHUDProvider());
+
+        defaultsRegistered = true;
+    }
+
+    public static void registerBlockProvider(Block block, InWorldHUDProvider provider) {
+        BLOCK_PROVIDERS.computeIfAbsent(block, $ -> new ArrayList<>()).add(provider);
+    }
+
+    public static void registerGenericProvider(InWorldHUDProvider provider) {
+        GENERIC_PROVIDERS.add(provider);
+    }
+
+    public static boolean hasProviders(Level level, BlockPos pos) {
+        return !getApplicableProviders(level, pos).isEmpty();
+    }
+
+    public static InWorldHUDSnapshot gatherClientSnapshot(Level level, BlockPos pos) {
+        List<InWorldHUDProvider> providers = getApplicableProviders(level, pos);
+        if (providers.isEmpty()) {
+            return InWorldHUDSnapshot.EMPTY;
+        }
+
+        BlockState state = level.getBlockState(pos);
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        InWorldHUDBuilder builder = new InWorldHUDBuilder();
+        providers.forEach(provider -> provider.appendClientData(builder, level, pos, state, blockEntity));
+        return builder.build();
+    }
+
+    public static InWorldHUDSnapshot gatherServerSnapshot(ServerPlayer player, ServerLevel level, BlockPos pos) {
+        List<InWorldHUDProvider> providers = getApplicableProviders(level, pos);
+        if (providers.isEmpty()) {
+            return InWorldHUDSnapshot.EMPTY;
+        }
+
+        BlockState state = level.getBlockState(pos);
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        InWorldHUDBuilder builder = new InWorldHUDBuilder();
+        providers.forEach(provider -> provider.appendServerData(builder, player, level, pos, state, blockEntity));
+        return builder.build();
+    }
+
+    private static List<InWorldHUDProvider> getApplicableProviders(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+
+        List<InWorldHUDProvider> blockProviders = BLOCK_PROVIDERS.getOrDefault(state.getBlock(), List.of());
+        if (blockProviders.isEmpty()) {
+            return List.of();
+        }
+
+        List<InWorldHUDProvider> result = new ArrayList<>();
+        blockProviders.stream().filter(provider -> provider.applies(level, pos, state, blockEntity)).forEach(result::add);
+        if (result.isEmpty()) {
+            return List.of();
+        }
+
+        GENERIC_PROVIDERS.stream().filter(provider -> provider.applies(level, pos, state, blockEntity)).forEach(result::add);
+        return result;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -82,17 +82,15 @@ public class InWorldHUDRegistry {
         BlockState state = level.getBlockState(pos);
         BlockEntity blockEntity = level.getBlockEntity(pos);
 
-        List<InWorldHUDProvider> blockProviders = BLOCK_PROVIDERS.getOrDefault(state.getBlock(), List.of());
-        if (blockProviders.isEmpty()) {
+        List<InWorldHUDProvider> applicableBlockProviders = BLOCK_PROVIDERS.getOrDefault(state.getBlock(), List.of()).stream()
+                .filter(provider -> provider.applies(level, pos, state, blockEntity))
+                .toList();
+
+        if (applicableBlockProviders.isEmpty()) {
             return List.of();
         }
 
-        List<InWorldHUDProvider> result = new ArrayList<>();
-        blockProviders.stream().filter(provider -> provider.applies(level, pos, state, blockEntity)).forEach(result::add);
-        if (result.isEmpty()) {
-            return List.of();
-        }
-
+        List<InWorldHUDProvider> result = new ArrayList<>(applicableBlockProviders);
         GENERIC_PROVIDERS.stream().filter(provider -> provider.applies(level, pos, state, blockEntity)).forEach(result::add);
         return result;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDSnapshot.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDSnapshot.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public record InWorldHUDSnapshot(Optional<Component> title, List<Component> lines, List<ItemStack> items) {
+
+    public static final InWorldHUDSnapshot EMPTY = new InWorldHUDSnapshot(Optional.empty(), List.of(), List.of());
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, InWorldHUDSnapshot> STREAM_CODEC = StreamCodec.composite(
+            ComponentSerialization.TRUSTED_OPTIONAL_STREAM_CODEC,
+            InWorldHUDSnapshot::title,
+            ComponentSerialization.TRUSTED_STREAM_CODEC.apply(ByteBufCodecs.collection(ArrayList::new)),
+            InWorldHUDSnapshot::lines,
+            ItemStack.STREAM_CODEC.apply(ByteBufCodecs.collection(ArrayList::new)),
+            InWorldHUDSnapshot::items,
+            InWorldHUDSnapshot::new
+    );
+
+    public InWorldHUDSnapshot {
+        title = title == null ? Optional.empty() : title;
+        lines = List.copyOf(lines);
+        items = items.stream().filter(stack -> !stack.isEmpty()).map(ItemStack::copy).toList();
+    }
+
+    public boolean isEmpty() {
+        return this.title.isEmpty() && this.lines.isEmpty() && this.items.isEmpty();
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/ItemStacksTooltip.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/ItemStacksTooltip.java
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+public record ItemStacksTooltip(List<ItemStack> items) implements TooltipComponent {
+
+    private static final int MAX_ITEMS = 9;
+
+    public ItemStacksTooltip {
+        items = items.stream().filter(stack -> !stack.isEmpty()).limit(MAX_ITEMS).map(ItemStack::copy).toList();
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/TopCenterTooltipPositioner.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/TopCenterTooltipPositioner.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud;
+
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipPositioner;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+
+public class TopCenterTooltipPositioner implements ClientTooltipPositioner {
+
+    public static final TopCenterTooltipPositioner INSTANCE = new TopCenterTooltipPositioner();
+
+    private TopCenterTooltipPositioner() {
+    }
+
+    @Override
+    public Vector2ic positionTooltip(int screenWidth, int screenHeight, int mouseX, int mouseY, int tooltipWidth, int tooltipHeight) {
+        int minX = 4;
+        int maxX = Math.max(minX, screenWidth - tooltipWidth - 4);
+        int x = Math.max(minX, Math.min((screenWidth - tooltipWidth) / 2, maxX));
+
+        int minY = 4;
+        int maxY = Math.max(minY, screenHeight - tooltipHeight - 3);
+        int y = Math.max(minY, Math.min(mouseY, maxY));
+
+        return new Vector2i(x, y);
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/ItemStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/ItemStorageInWorldHUDProvider.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import com.klikli_dev.theurgy.content.storage.ItemStorageHelper;
+import com.klikli_dev.theurgy.registry.CapabilityRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+import org.jetbrains.annotations.Nullable;
+
+public class ItemStorageInWorldHUDProvider implements InWorldHUDProvider {
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return level.getCapability(CapabilityRegistry.ITEM_HANDLER, pos, state, blockEntity, null) != null;
+    }
+
+    @Override
+    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        ResourceHandler<ItemResource> itemHandler = level.getCapability(CapabilityRegistry.ITEM_HANDLER, pos, state, blockEntity, null);
+        if (itemHandler == null) {
+            return;
+        }
+
+        for (int slot = 0; slot < itemHandler.size(); slot++) {
+            builder.addItem(ItemStorageHelper.getStackInSlot(itemHandler, slot));
+        }
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryCatalystInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryCatalystInWorldHUDProvider.java
@@ -8,8 +8,6 @@ import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
 import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -24,11 +22,6 @@ public class MercuryCatalystInWorldHUDProvider implements InWorldHUDProvider {
 
     @Override
     public void appendClientData(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
-        builder.setTitleIfAbsent(state.getBlock().getName());
-    }
-
-    @Override
-    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
         builder.setTitleIfAbsent(state.getBlock().getName());
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryCatalystInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryCatalystInWorldHUDProvider.java
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import com.klikli_dev.theurgy.registry.BlockRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public class MercuryCatalystInWorldHUDProvider implements InWorldHUDProvider {
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return state.is(BlockRegistry.MERCURY_CATALYST.get());
+    }
+
+    @Override
+    public void appendClientData(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        builder.setTitleIfAbsent(state.getBlock().getName());
+    }
+
+    @Override
+    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        builder.setTitleIfAbsent(state.getBlock().getName());
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxStorageInWorldHUDProvider.java
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.TheurgyConstants;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import com.klikli_dev.theurgy.registry.CapabilityRegistry;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public class MercuryFluxStorageInWorldHUDProvider implements InWorldHUDProvider {
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return level.getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, pos, state, blockEntity, null) != null;
+    }
+
+    @Override
+    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        this.addFluxLine(builder, level, pos, state, blockEntity);
+    }
+
+    private void addFluxLine(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        var storage = level.getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, pos, state, blockEntity, null);
+        if (storage == null) {
+            return;
+        }
+
+        builder.addLine(Component.translatable(
+                TheurgyConstants.I18n.JEI.MERCURY_FLUX,
+                storage.getEnergyStored() + " / " + storage.getMaxEnergyStored()
+        ).withStyle(ChatFormatting.GRAY));
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
@@ -1274,6 +1274,7 @@ public class ENUSProvider extends AbstractModonomiconLanguageProvider implements
         this.addConfig("rendering", "Rendering Settings");
         this.addConfig("renderSulfurSourceItem", "Render Sulfur Source Items");
         this.addConfig("enableItemHUD", "Enable Item HUD");
+        this.addConfig("enableInWorldHUD", "Enable In-World HUD");
         this.addConfig("hudScale", "HUD Scale");
 
         this.addConfig("misc", "Misc Settings");

--- a/src/main/java/com/klikli_dev/theurgy/network/Networking.java
+++ b/src/main/java/com/klikli_dev/theurgy/network/Networking.java
@@ -26,6 +26,7 @@ public class Networking {
         registrar.playToServer(MessageClearMenu.TYPE, MessageClearMenu.STREAM_CODEC, MessageHandler::handle);
         registrar.playToServer(MessageSetListFilterScreenOption.TYPE, MessageSetListFilterScreenOption.STREAM_CODEC, MessageHandler::handle);
         registrar.playToServer(MessageOnLeftClickEmpty.TYPE, MessageOnLeftClickEmpty.STREAM_CODEC, MessageHandler::handle);
+        registrar.playToServer(MessageRequestInWorldHUD.TYPE, MessageRequestInWorldHUD.STREAM_CODEC, MessageHandler::handle);
 
         //to client
         registrar.playToClient(MessageRequestCaloricFluxEmitterSelection.TYPE, MessageRequestCaloricFluxEmitterSelection.STREAM_CODEC, MessageHandler::handle);
@@ -37,6 +38,7 @@ public class Networking {
         registrar.playToClient(MessageAddWires.TYPE, MessageAddWires.STREAM_CODEC, MessageHandler::handle);
         registrar.playToClient(MessageRemoveWires.TYPE, MessageRemoveWires.STREAM_CODEC, MessageHandler::handle);
         registrar.playToClient(MessageSyncSulfursWithoutRecipe.TYPE, MessageSyncSulfursWithoutRecipe.STREAM_CODEC, MessageHandler::handle);
+        registrar.playToClient(MessageSyncInWorldHUD.TYPE, MessageSyncInWorldHUD.STREAM_CODEC, MessageHandler::handle);
     }
 
 

--- a/src/main/java/com/klikli_dev/theurgy/network/messages/MessageRequestInWorldHUD.java
+++ b/src/main/java/com/klikli_dev/theurgy/network/messages/MessageRequestInWorldHUD.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.network.messages;
+
+import com.klikli_dev.theurgy.Theurgy;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDRegistry;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDSnapshot;
+import com.klikli_dev.theurgy.network.Message;
+import com.klikli_dev.theurgy.network.Networking;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import org.jetbrains.annotations.NotNull;
+
+public record MessageRequestInWorldHUD(BlockPos pos) implements Message {
+
+    public static final Type<MessageRequestInWorldHUD> TYPE = new Type<>(Theurgy.loc("request_in_world_hud"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, MessageRequestInWorldHUD> STREAM_CODEC = StreamCodec.composite(
+            BlockPos.STREAM_CODEC,
+            MessageRequestInWorldHUD::pos,
+            MessageRequestInWorldHUD::new
+    );
+
+    @Override
+    public void onServerReceived(MinecraftServer minecraftServer, ServerPlayer player) {
+        ServerLevel level = (ServerLevel) player.level();
+        InWorldHUDSnapshot snapshot = InWorldHUDSnapshot.EMPTY;
+
+        if (level.isLoaded(this.pos) && player.isWithinBlockInteractionRange(this.pos, 1.0) && this.isActuallyLookingAt(player, level)) {
+            snapshot = InWorldHUDRegistry.gatherServerSnapshot(player, level, this.pos);
+        }
+
+        Networking.sendTo(player, new MessageSyncInWorldHUD(this.pos, snapshot));
+    }
+
+    private boolean isActuallyLookingAt(ServerPlayer player, ServerLevel level) {
+        var eyePosition = player.getEyePosition();
+        var lookTarget = eyePosition.add(player.calculateViewVector(player.getXRot(), player.getYRot()).scale(player.blockInteractionRange()));
+        BlockHitResult hitResult = level.clip(new ClipContext(eyePosition, lookTarget, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player));
+        return hitResult.getType() == HitResult.Type.BLOCK && this.pos.equals(hitResult.getBlockPos());
+    }
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/network/messages/MessageRequestInWorldHUD.java
+++ b/src/main/java/com/klikli_dev/theurgy/network/messages/MessageRequestInWorldHUD.java
@@ -35,7 +35,7 @@ public record MessageRequestInWorldHUD(BlockPos pos) implements Message {
         ServerLevel level = (ServerLevel) player.level();
         InWorldHUDSnapshot snapshot = InWorldHUDSnapshot.EMPTY;
 
-        if (level.isLoaded(this.pos) && player.isWithinBlockInteractionRange(this.pos, 1.0) && this.isActuallyLookingAt(player, level)) {
+        if (level.isLoaded(this.pos) && this.isActuallyLookingAt(player, level)) {
             snapshot = InWorldHUDRegistry.gatherServerSnapshot(player, level, this.pos);
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/network/messages/MessageSyncInWorldHUD.java
+++ b/src/main/java/com/klikli_dev/theurgy/network/messages/MessageSyncInWorldHUD.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.network.messages;
+
+import com.klikli_dev.theurgy.Theurgy;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUD;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDSnapshot;
+import com.klikli_dev.theurgy.network.Message;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.NotNull;
+
+public record MessageSyncInWorldHUD(BlockPos pos, InWorldHUDSnapshot snapshot) implements Message {
+
+    public static final Type<MessageSyncInWorldHUD> TYPE = new Type<>(Theurgy.loc("sync_in_world_hud"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, MessageSyncInWorldHUD> STREAM_CODEC = StreamCodec.composite(
+            BlockPos.STREAM_CODEC,
+            MessageSyncInWorldHUD::pos,
+            InWorldHUDSnapshot.STREAM_CODEC,
+            MessageSyncInWorldHUD::snapshot,
+            MessageSyncInWorldHUD::new
+    );
+
+    @Override
+    public void onClientReceived(Minecraft minecraft, Player player) {
+        InWorldHUD.get().acceptServerSnapshot(this.pos, this.snapshot);
+    }
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple top-center in-world HUD that renders tooltip-style block information while looking at supported machines
- sync live block HUD data through a generic request/response pipeline with reusable block and capability-based providers
- wire the first rollout for the mercury catalyst, showing its mercury flux storage and contained item stacks plus a client toggle to disable the overlay