### PR TITLE
fix: correct Sal Ammoniac tank fluid rendering

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -30,6 +30,52 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         super(pContext, new SalAmmoniacTankModel());
     }
 
+    private static void putSideFace(
+            VertexConsumer builder,
+            PoseStack.Pose pose,
+            Direction face,
+            float horizontalMin,
+            float horizontalMax,
+            float yMin,
+            float yMax,
+            float depth,
+            int color,
+            float u0,
+            float u1,
+            float vTop,
+            float vBottom,
+            int light
+    ) {
+        switch (face) {
+            case NORTH -> {
+                putVertex(builder, pose, horizontalMin, yMax, depth, color, u0, vTop, face, light);
+                putVertex(builder, pose, horizontalMin, yMin, depth, color, u0, vBottom, face, light);
+                putVertex(builder, pose, horizontalMax, yMin, depth, color, u1, vBottom, face, light);
+                putVertex(builder, pose, horizontalMax, yMax, depth, color, u1, vTop, face, light);
+            }
+            case SOUTH -> {
+                putVertex(builder, pose, horizontalMax, yMax, depth, color, u0, vTop, face, light);
+                putVertex(builder, pose, horizontalMax, yMin, depth, color, u0, vBottom, face, light);
+                putVertex(builder, pose, horizontalMin, yMin, depth, color, u1, vBottom, face, light);
+                putVertex(builder, pose, horizontalMin, yMax, depth, color, u1, vTop, face, light);
+            }
+            case WEST -> {
+                putVertex(builder, pose, depth, yMax, horizontalMax, color, u0, vTop, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMax, color, u0, vBottom, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMin, color, u1, vBottom, face, light);
+                putVertex(builder, pose, depth, yMax, horizontalMin, color, u1, vTop, face, light);
+            }
+            case EAST -> {
+                putVertex(builder, pose, depth, yMax, horizontalMin, color, u0, vTop, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMin, color, u0, vBottom, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMax, color, u1, vBottom, face, light);
+                putVertex(builder, pose, depth, yMax, horizontalMax, color, u1, vTop, face, light);
+            }
+            default -> {
+            }
+        }
+    }
+
     private static void putVertex(VertexConsumer builder, PoseStack.Pose pose, float x, float y, float z, int color, float u, float v, Direction face, int light) {
         Vec3i normal = face.getUnitVec3i();
         int a = color >> 24 & 0xff;
@@ -88,12 +134,13 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
                 ? FluidRenderer.getFluidColor(fluidStack, clientLevel, blockEntity.getBlockPos())
                 : FluidRenderer.getFluidColor(fluidStack);
         state.fluidLight = (state.lightCoords & 0xF00000) | luminosity << 4;
-        state.fluidStack = fluidStack.copy();
+        state.bottomY = capHeight + minPuddleHeight;
         state.surfaceY = capHeight + minPuddleHeight + clampedLevel;
         state.u0 = sprite.getU0();
         state.u1 = sprite.getU1();
         state.v0 = sprite.getV0();
         state.v1 = sprite.getV1();
+        state.sideV0 = Mth.lerp(1 - fluidHeight, state.v0, state.v1);
     }
 
     @Override
@@ -110,21 +157,20 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         float xMax = xMin + blockWidth - 2 * tankHullWidth;
         float zMin = tankHullWidth;
         float zMax = zMin + blockWidth - 2 * tankHullWidth;
-        float yMin = 1 / 4f + 1 / 16f;
+        float yMin = state.bottomY;
 
         poseStack.pushPose();
 
-        var fluidTexture = FluidRenderer.getFluidTexture(state.fluidStack, FluidRenderer.FluidTextureType.STILL);
         submitNodeCollector.submitCustomGeometry(poseStack, RenderTypes.fluid(), (pose, builder) -> {
             putVertex(builder, pose, xMin, state.surfaceY, zMin, state.color, state.u0, state.v0, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMin, state.surfaceY, zMax, state.color, state.u0, state.v1, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMax, state.surfaceY, zMax, state.color, state.u1, state.v1, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMax, state.surfaceY, zMin, state.color, state.u1, state.v0, Direction.UP, state.fluidLight);
 
-            FluidRenderer.renderStillTiledFace(Direction.NORTH, xMin, yMin, xMax, state.surfaceY, zMin, builder, pose, state.fluidLight, state.color, fluidTexture);
-            FluidRenderer.renderStillTiledFace(Direction.SOUTH, xMin, yMin, xMax, state.surfaceY, zMax, builder, pose, state.fluidLight, state.color, fluidTexture);
-            FluidRenderer.renderStillTiledFace(Direction.WEST, zMin, yMin, zMax, state.surfaceY, xMin, builder, pose, state.fluidLight, state.color, fluidTexture);
-            FluidRenderer.renderStillTiledFace(Direction.EAST, zMin, yMin, zMax, state.surfaceY, xMax, builder, pose, state.fluidLight, state.color, fluidTexture);
+            putSideFace(builder, pose, Direction.NORTH, xMin, xMax, yMin, state.surfaceY, zMin, state.color, state.u0, state.u1, state.sideV0, state.v1, state.fluidLight);
+            putSideFace(builder, pose, Direction.SOUTH, xMin, xMax, yMin, state.surfaceY, zMax, state.color, state.u0, state.u1, state.sideV0, state.v1, state.fluidLight);
+            putSideFace(builder, pose, Direction.WEST, zMin, zMax, yMin, state.surfaceY, xMin, state.color, state.u0, state.u1, state.sideV0, state.v1, state.fluidLight);
+            putSideFace(builder, pose, Direction.EAST, zMin, zMax, yMin, state.surfaceY, xMax, state.color, state.u0, state.u1, state.sideV0, state.v1, state.fluidLight);
         });
 
         poseStack.popPose();
@@ -134,11 +180,12 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         public boolean empty = true;
         public int color;
         public int fluidLight;
-        public net.neoforged.neoforge.fluids.FluidStack fluidStack;
+        public float bottomY;
         public float surfaceY;
         public float u0;
         public float u1;
         public float v0;
         public float v1;
+        public float sideV0;
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -88,6 +88,7 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
                 ? FluidRenderer.getFluidColor(fluidStack, clientLevel, blockEntity.getBlockPos())
                 : FluidRenderer.getFluidColor(fluidStack);
         state.fluidLight = (state.lightCoords & 0xF00000) | luminosity << 4;
+        state.fluidStack = fluidStack.copy();
         state.surfaceY = capHeight + minPuddleHeight + clampedLevel;
         state.u0 = sprite.getU0();
         state.u1 = sprite.getU1();
@@ -109,14 +110,21 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         float xMax = xMin + blockWidth - 2 * tankHullWidth;
         float zMin = tankHullWidth;
         float zMax = zMin + blockWidth - 2 * tankHullWidth;
+        float yMin = 1 / 4f + 1 / 16f;
 
         poseStack.pushPose();
 
+        var fluidTexture = FluidRenderer.getFluidTexture(state.fluidStack, FluidRenderer.FluidTextureType.STILL);
         submitNodeCollector.submitCustomGeometry(poseStack, RenderTypes.fluid(), (pose, builder) -> {
             putVertex(builder, pose, xMin, state.surfaceY, zMin, state.color, state.u0, state.v0, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMin, state.surfaceY, zMax, state.color, state.u0, state.v1, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMax, state.surfaceY, zMax, state.color, state.u1, state.v1, Direction.UP, state.fluidLight);
             putVertex(builder, pose, xMax, state.surfaceY, zMin, state.color, state.u1, state.v0, Direction.UP, state.fluidLight);
+
+            FluidRenderer.renderStillTiledFace(Direction.NORTH, xMin, yMin, xMax, state.surfaceY, zMin, builder, pose, state.fluidLight, state.color, fluidTexture);
+            FluidRenderer.renderStillTiledFace(Direction.SOUTH, xMin, yMin, xMax, state.surfaceY, zMax, builder, pose, state.fluidLight, state.color, fluidTexture);
+            FluidRenderer.renderStillTiledFace(Direction.WEST, zMin, yMin, zMax, state.surfaceY, xMin, builder, pose, state.fluidLight, state.color, fluidTexture);
+            FluidRenderer.renderStillTiledFace(Direction.EAST, zMin, yMin, zMax, state.surfaceY, xMax, builder, pose, state.fluidLight, state.color, fluidTexture);
         });
 
         poseStack.popPose();
@@ -126,6 +134,7 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         public boolean empty = true;
         public int color;
         public int fluidLight;
+        public net.neoforged.neoforge.fluids.FluidStack fluidStack;
         public float surfaceY;
         public float u0;
         public float u1;

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -134,7 +134,7 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
                 ? FluidRenderer.getFluidColor(fluidStack, clientLevel, blockEntity.getBlockPos())
                 : FluidRenderer.getFluidColor(fluidStack);
         state.fluidLight = (state.lightCoords & 0xF00000) | luminosity << 4;
-        state.bottomY = capHeight + minPuddleHeight;
+        state.bottomY = capHeight;
         state.surfaceY = capHeight + minPuddleHeight + clampedLevel;
         state.u0 = sprite.getU0();
         state.u1 = sprite.getU1();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -6,6 +6,8 @@ package com.klikli_dev.theurgy.content.apparatus.salammoniactank.render;
 
 import com.geckolib.renderer.GeoBlockRenderer;
 import com.klikli_dev.theurgy.content.apparatus.salammoniactank.SalAmmoniacTankBlockEntity;
+import com.klikli_dev.theurgy.content.fluid.SolventFluidType;
+import com.klikli_dev.theurgy.content.render.FluidRenderer;
 import com.klikli_dev.theurgy.content.render.RenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -80,10 +82,19 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         float clampedLevel = Mth.clamp(fluidHeight * totalHeight, 0, totalHeight);
         int blockLightIn = (state.lightCoords >> 4) & 0xF;
         int luminosity = Math.max(blockLightIn, fluidType.getLightLevel(fluidStack));
+        var sprite = FluidRenderer.getFluidTexture(fluidStack, FluidRenderer.FluidTextureType.STILL);
 
-        state.color = 0xFFFFFFFF; // SAL_AMMONIAC uses water base, default no-tint (IClientFluidTypeExtensions.getTintColor removed)
+        if (fluidType instanceof SolventFluidType solventFluidType) {
+            state.color = solventFluidType.tint;
+        } else {
+            state.color = 0xFFFFFFFF;
+        }
         state.fluidLight = (state.lightCoords & 0xF00000) | luminosity << 4;
         state.surfaceY = capHeight + minPuddleHeight + clampedLevel;
+        state.u0 = sprite.getU0();
+        state.u1 = sprite.getU1();
+        state.v0 = sprite.getV0();
+        state.v1 = sprite.getV1();
     }
 
     @Override
@@ -102,13 +113,12 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         float zMax = zMin + blockWidth - 2 * tankHullWidth;
 
         poseStack.pushPose();
-        poseStack.translate(-0.5f, 0, -0.5f);
 
         submitNodeCollector.submitCustomGeometry(poseStack, RenderTypes.fluid(), (pose, builder) -> {
-            putVertex(builder, pose, xMin, state.surfaceY, zMin, state.color, 0.0f, 0.0f, Direction.UP, state.fluidLight);
-            putVertex(builder, pose, xMin, state.surfaceY, zMax, state.color, 0.0f, 1.0f, Direction.UP, state.fluidLight);
-            putVertex(builder, pose, xMax, state.surfaceY, zMax, state.color, 1.0f, 1.0f, Direction.UP, state.fluidLight);
-            putVertex(builder, pose, xMax, state.surfaceY, zMin, state.color, 1.0f, 0.0f, Direction.UP, state.fluidLight);
+            putVertex(builder, pose, xMin, state.surfaceY, zMin, state.color, state.u0, state.v0, Direction.UP, state.fluidLight);
+            putVertex(builder, pose, xMin, state.surfaceY, zMax, state.color, state.u0, state.v1, Direction.UP, state.fluidLight);
+            putVertex(builder, pose, xMax, state.surfaceY, zMax, state.color, state.u1, state.v1, Direction.UP, state.fluidLight);
+            putVertex(builder, pose, xMax, state.surfaceY, zMin, state.color, state.u1, state.v0, Direction.UP, state.fluidLight);
         });
 
         poseStack.popPose();
@@ -119,5 +129,9 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         public int color;
         public int fluidLight;
         public float surfaceY;
+        public float u0;
+        public float u1;
+        public float v0;
+        public float v1;
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -48,28 +48,28 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
     ) {
         switch (face) {
             case NORTH -> {
-                putVertex(builder, pose, horizontalMin, yMax, depth, color, u0, vTop, face, light);
                 putVertex(builder, pose, horizontalMin, yMin, depth, color, u0, vBottom, face, light);
-                putVertex(builder, pose, horizontalMax, yMin, depth, color, u1, vBottom, face, light);
+                putVertex(builder, pose, horizontalMin, yMax, depth, color, u0, vTop, face, light);
                 putVertex(builder, pose, horizontalMax, yMax, depth, color, u1, vTop, face, light);
+                putVertex(builder, pose, horizontalMax, yMin, depth, color, u1, vBottom, face, light);
             }
             case SOUTH -> {
-                putVertex(builder, pose, horizontalMax, yMax, depth, color, u0, vTop, face, light);
                 putVertex(builder, pose, horizontalMax, yMin, depth, color, u0, vBottom, face, light);
-                putVertex(builder, pose, horizontalMin, yMin, depth, color, u1, vBottom, face, light);
+                putVertex(builder, pose, horizontalMax, yMax, depth, color, u0, vTop, face, light);
                 putVertex(builder, pose, horizontalMin, yMax, depth, color, u1, vTop, face, light);
+                putVertex(builder, pose, horizontalMin, yMin, depth, color, u1, vBottom, face, light);
             }
             case WEST -> {
-                putVertex(builder, pose, depth, yMax, horizontalMax, color, u0, vTop, face, light);
                 putVertex(builder, pose, depth, yMin, horizontalMax, color, u0, vBottom, face, light);
-                putVertex(builder, pose, depth, yMin, horizontalMin, color, u1, vBottom, face, light);
+                putVertex(builder, pose, depth, yMax, horizontalMax, color, u0, vTop, face, light);
                 putVertex(builder, pose, depth, yMax, horizontalMin, color, u1, vTop, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMin, color, u1, vBottom, face, light);
             }
             case EAST -> {
-                putVertex(builder, pose, depth, yMax, horizontalMin, color, u0, vTop, face, light);
                 putVertex(builder, pose, depth, yMin, horizontalMin, color, u0, vBottom, face, light);
-                putVertex(builder, pose, depth, yMin, horizontalMax, color, u1, vBottom, face, light);
+                putVertex(builder, pose, depth, yMax, horizontalMin, color, u0, vTop, face, light);
                 putVertex(builder, pose, depth, yMax, horizontalMax, color, u1, vTop, face, light);
+                putVertex(builder, pose, depth, yMin, horizontalMax, color, u1, vBottom, face, light);
             }
             default -> {
             }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniactank/render/SalAmmoniacTankRenderer.java
@@ -6,11 +6,11 @@ package com.klikli_dev.theurgy.content.apparatus.salammoniactank.render;
 
 import com.geckolib.renderer.GeoBlockRenderer;
 import com.klikli_dev.theurgy.content.apparatus.salammoniactank.SalAmmoniacTankBlockEntity;
-import com.klikli_dev.theurgy.content.fluid.SolventFluidType;
 import com.klikli_dev.theurgy.content.render.FluidRenderer;
 import com.klikli_dev.theurgy.content.render.RenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
@@ -84,11 +84,9 @@ public class SalAmmoniacTankRenderer extends GeoBlockRenderer<SalAmmoniacTankBlo
         int luminosity = Math.max(blockLightIn, fluidType.getLightLevel(fluidStack));
         var sprite = FluidRenderer.getFluidTexture(fluidStack, FluidRenderer.FluidTextureType.STILL);
 
-        if (fluidType instanceof SolventFluidType solventFluidType) {
-            state.color = solventFluidType.tint;
-        } else {
-            state.color = 0xFFFFFFFF;
-        }
+        state.color = blockEntity.getLevel() instanceof ClientLevel clientLevel
+                ? FluidRenderer.getFluidColor(fluidStack, clientLevel, blockEntity.getBlockPos())
+                : FluidRenderer.getFluidColor(fluidStack);
         state.fluidLight = (state.lightCoords & 0xF00000) | luminosity << 4;
         state.surfaceY = capHeight + minPuddleHeight + clampedLevel;
         state.u0 = sprite.getU0();

--- a/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
@@ -114,21 +114,11 @@ public class FluidRenderer {
 
     public static void renderStillTiledFace(Direction dir, float left, float down, float right, float up, float depth,
                                             VertexConsumer builder, PoseStack ms, int light, int color, TextureAtlasSprite texture) {
-        FluidRenderer.renderStillTiledFace(dir, left, down, right, up, depth, builder, ms.last(), light, color, texture);
-    }
-
-    public static void renderStillTiledFace(Direction dir, float left, float down, float right, float up, float depth,
-                                            VertexConsumer builder, PoseStack.Pose pose, int light, int color, TextureAtlasSprite texture) {
-        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, pose, light, color, texture, 1);
+        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, ms, light, color, texture, 1);
     }
 
     public static void renderTiledFace(Direction dir, float left, float down, float right, float up, float depth,
                                        VertexConsumer builder, PoseStack ms, int light, int color, TextureAtlasSprite texture, float textureScale) {
-        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, ms.last(), light, color, texture, textureScale);
-    }
-
-    public static void renderTiledFace(Direction dir, float left, float down, float right, float up, float depth,
-                                       VertexConsumer builder, PoseStack.Pose pose, int light, int color, TextureAtlasSprite texture, float textureScale) {
         boolean positive = dir.getAxisDirection() == Direction.AxisDirection.POSITIVE;
         boolean horizontal = dir.getAxis()
                 .isHorizontal();
@@ -172,46 +162,42 @@ public class FluidRenderer {
 
                 if (horizontal) {
                     if (x) {
-                        putVertex(builder, pose, depth, y2, positive ? x2 : x1, color, u1, v1, dir, light);
-                        putVertex(builder, pose, depth, y1, positive ? x2 : x1, color, u1, v2, dir, light);
-                        putVertex(builder, pose, depth, y1, positive ? x1 : x2, color, u2, v2, dir, light);
-                        putVertex(builder, pose, depth, y2, positive ? x1 : x2, color, u2, v1, dir, light);
+                        putVertex(builder, ms, depth, y2, positive ? x2 : x1, color, u1, v1, dir, light);
+                        putVertex(builder, ms, depth, y1, positive ? x2 : x1, color, u1, v2, dir, light);
+                        putVertex(builder, ms, depth, y1, positive ? x1 : x2, color, u2, v2, dir, light);
+                        putVertex(builder, ms, depth, y2, positive ? x1 : x2, color, u2, v1, dir, light);
                     } else {
-                        putVertex(builder, pose, positive ? x1 : x2, y2, depth, color, u1, v1, dir, light);
-                        putVertex(builder, pose, positive ? x1 : x2, y1, depth, color, u1, v2, dir, light);
-                        putVertex(builder, pose, positive ? x2 : x1, y1, depth, color, u2, v2, dir, light);
-                        putVertex(builder, pose, positive ? x2 : x1, y2, depth, color, u2, v1, dir, light);
+                        putVertex(builder, ms, positive ? x1 : x2, y2, depth, color, u1, v1, dir, light);
+                        putVertex(builder, ms, positive ? x1 : x2, y1, depth, color, u1, v2, dir, light);
+                        putVertex(builder, ms, positive ? x2 : x1, y1, depth, color, u2, v2, dir, light);
+                        putVertex(builder, ms, positive ? x2 : x1, y2, depth, color, u2, v1, dir, light);
                     }
                 } else {
-                    putVertex(builder, pose, x1, depth, positive ? y1 : y2, color, u1, v1, dir, light);
-                    putVertex(builder, pose, x1, depth, positive ? y2 : y1, color, u1, v2, dir, light);
-                    putVertex(builder, pose, x2, depth, positive ? y2 : y1, color, u2, v2, dir, light);
-                    putVertex(builder, pose, x2, depth, positive ? y1 : y2, color, u2, v1, dir, light);
+                    putVertex(builder, ms, x1, depth, positive ? y1 : y2, color, u1, v1, dir, light);
+                    putVertex(builder, ms, x1, depth, positive ? y2 : y1, color, u1, v2, dir, light);
+                    putVertex(builder, ms, x2, depth, positive ? y2 : y1, color, u2, v2, dir, light);
+                    putVertex(builder, ms, x2, depth, positive ? y1 : y2, color, u2, v1, dir, light);
                 }
             }
         }
     }
 
-    private static void putVertex(VertexConsumer builder, PoseStack.Pose pose, float x, float y, float z, int color, float u,
+    private static void putVertex(VertexConsumer builder, PoseStack ms, float x, float y, float z, int color, float u,
                                   float v, Direction face, int light) {
 
         Vec3i normal = face.getUnitVec3i();
+        PoseStack.Pose peek = ms.last();
         int a = color >> 24 & 0xff;
         int r = color >> 16 & 0xff;
         int g = color >> 8 & 0xff;
         int b = color & 0xff;
 
-        builder.addVertex(pose.pose(), x, y, z)
+        builder.addVertex(peek.pose(), x, y, z)
                 .setColor(r, g, b, a)
                 .setUv(u, v)
                 .setOverlay(OverlayTexture.NO_OVERLAY)
                 .setLight(light)
-                .setNormal(pose, normal.getX(), normal.getY(), normal.getZ());
-    }
-
-    private static void putVertex(VertexConsumer builder, PoseStack ms, float x, float y, float z, int color, float u,
-                                  float v, Direction face, int light) {
-        putVertex(builder, ms.last(), x, y, z, color, u, v, face, light);
+                .setNormal(peek, normal.getX(), normal.getY(), normal.getZ());
     }
 
     public enum FluidTextureType {

--- a/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
@@ -10,20 +10,23 @@ package com.klikli_dev.theurgy.content.render;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
-import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import com.klikli_dev.theurgy.content.fluid.SolventFluidType;
+import net.neoforged.neoforge.client.fluid.FluidTintSources;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * See com.simibubi.create.foundation.fluid.FluidRenderer
@@ -31,14 +34,35 @@ import org.jetbrains.annotations.NotNull;
 public class FluidRenderer {
 
     public static TextureAtlasSprite getFluidTexture(@NotNull FluidStack fluidStack, @NotNull FluidTextureType type) {
+        FluidState fluidState = fluidStack.getFluid().defaultFluidState();
+        var model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState);
+        var material = type == FluidTextureType.STILL ? model.stillMaterial() : model.flowingMaterial();
+        return material.sprite();
+    }
+
+    public static int getFluidColor(@NotNull FluidStack fluidStack) {
+        return getFluidColor(fluidStack, null, null);
+    }
+
+    public static int getFluidColor(@NotNull FluidStack fluidStack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
         FluidType fluidType = fluidStack.getFluid().getFluidType();
-        Identifier spriteLocation;
-        if (fluidType instanceof SolventFluidType solventFluidType) {
-            spriteLocation = type == FluidTextureType.STILL ? solventFluidType.still : solventFluidType.flowing;
-        } else {
-            spriteLocation = Identifier.withDefaultNamespace("block/water_still");
+        FluidState fluidState = fluidStack.getFluid().defaultFluidState();
+        var model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState);
+        var tintSource = FluidTintSources.of(model.tintSource());
+
+        if (tintSource != null) {
+            if (level != null && pos != null) {
+                return tintSource.colorInWorld(fluidState, fluidState.createLegacyBlock(), level, pos);
+            }
+
+            return tintSource.colorAsStack(fluidStack);
         }
-        return ((TextureAtlas) Minecraft.getInstance().getTextureManager().getTexture(TextureAtlas.LOCATION_BLOCKS)).getSprite(spriteLocation);
+
+        if (fluidType instanceof SolventFluidType solventFluidType) {
+            return solventFluidType.tint;
+        }
+
+        return 0xFFFFFFFF;
     }
 
     public static VertexConsumer getFluidBuilder(MultiBufferSource buffer) {
@@ -56,18 +80,8 @@ public class FluidRenderer {
         Fluid fluid = fluidStack.getFluid();
         FluidType fluidAttributes = fluid.getFluidType();
 
-        Identifier stillTexture;
-        int color;
-        if (fluidAttributes instanceof SolventFluidType solventFluidType) {
-            stillTexture = solventFluidType.still;
-            color = solventFluidType.tint;
-        } else {
-            stillTexture = Identifier.withDefaultNamespace("block/water_still");
-            color = 0xFFFFFFFF;
-        }
-
-        TextureAtlasSprite fluidTexture = ((TextureAtlas) Minecraft.getInstance().getTextureManager().getTexture(TextureAtlas.LOCATION_BLOCKS))
-                .getSprite(stillTexture);
+        int color = getFluidColor(fluidStack);
+        TextureAtlasSprite fluidTexture = getFluidTexture(fluidStack, FluidTextureType.STILL);
         int blockLightIn = (light >> 4) & 0xF;
         int luminosity = Math.max(blockLightIn, fluidAttributes.getLightLevel(fluidStack));
         light = (light & 0xF00000) | luminosity << 4;

--- a/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/FluidRenderer.java
@@ -114,11 +114,21 @@ public class FluidRenderer {
 
     public static void renderStillTiledFace(Direction dir, float left, float down, float right, float up, float depth,
                                             VertexConsumer builder, PoseStack ms, int light, int color, TextureAtlasSprite texture) {
-        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, ms, light, color, texture, 1);
+        FluidRenderer.renderStillTiledFace(dir, left, down, right, up, depth, builder, ms.last(), light, color, texture);
+    }
+
+    public static void renderStillTiledFace(Direction dir, float left, float down, float right, float up, float depth,
+                                            VertexConsumer builder, PoseStack.Pose pose, int light, int color, TextureAtlasSprite texture) {
+        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, pose, light, color, texture, 1);
     }
 
     public static void renderTiledFace(Direction dir, float left, float down, float right, float up, float depth,
                                        VertexConsumer builder, PoseStack ms, int light, int color, TextureAtlasSprite texture, float textureScale) {
+        FluidRenderer.renderTiledFace(dir, left, down, right, up, depth, builder, ms.last(), light, color, texture, textureScale);
+    }
+
+    public static void renderTiledFace(Direction dir, float left, float down, float right, float up, float depth,
+                                       VertexConsumer builder, PoseStack.Pose pose, int light, int color, TextureAtlasSprite texture, float textureScale) {
         boolean positive = dir.getAxisDirection() == Direction.AxisDirection.POSITIVE;
         boolean horizontal = dir.getAxis()
                 .isHorizontal();
@@ -160,51 +170,48 @@ public class FluidRenderer {
                 v1 = Mth.lerp(shrink, v1, centerV);
                 v2 = Mth.lerp(shrink, v2, centerV);
 
-                //Hack: the UV calculation doesn't work on 1.20.4, so we just use the full texture for now
-                //TODO: fix this for 1.20.4
-                u1 = texture.getU0();
-                u2 = texture.getU1();
-                v1 = texture.getV0();
-                v2 = texture.getV1();
-
                 if (horizontal) {
                     if (x) {
-                        putVertex(builder, ms, depth, y2, positive ? x2 : x1, color, u1, v1, dir, light);
-                        putVertex(builder, ms, depth, y1, positive ? x2 : x1, color, u1, v2, dir, light);
-                        putVertex(builder, ms, depth, y1, positive ? x1 : x2, color, u2, v2, dir, light);
-                        putVertex(builder, ms, depth, y2, positive ? x1 : x2, color, u2, v1, dir, light);
+                        putVertex(builder, pose, depth, y2, positive ? x2 : x1, color, u1, v1, dir, light);
+                        putVertex(builder, pose, depth, y1, positive ? x2 : x1, color, u1, v2, dir, light);
+                        putVertex(builder, pose, depth, y1, positive ? x1 : x2, color, u2, v2, dir, light);
+                        putVertex(builder, pose, depth, y2, positive ? x1 : x2, color, u2, v1, dir, light);
                     } else {
-                        putVertex(builder, ms, positive ? x1 : x2, y2, depth, color, u1, v1, dir, light);
-                        putVertex(builder, ms, positive ? x1 : x2, y1, depth, color, u1, v2, dir, light);
-                        putVertex(builder, ms, positive ? x2 : x1, y1, depth, color, u2, v2, dir, light);
-                        putVertex(builder, ms, positive ? x2 : x1, y2, depth, color, u2, v1, dir, light);
+                        putVertex(builder, pose, positive ? x1 : x2, y2, depth, color, u1, v1, dir, light);
+                        putVertex(builder, pose, positive ? x1 : x2, y1, depth, color, u1, v2, dir, light);
+                        putVertex(builder, pose, positive ? x2 : x1, y1, depth, color, u2, v2, dir, light);
+                        putVertex(builder, pose, positive ? x2 : x1, y2, depth, color, u2, v1, dir, light);
                     }
                 } else {
-                    putVertex(builder, ms, x1, depth, positive ? y1 : y2, color, u1, v1, dir, light);
-                    putVertex(builder, ms, x1, depth, positive ? y2 : y1, color, u1, v2, dir, light);
-                    putVertex(builder, ms, x2, depth, positive ? y2 : y1, color, u2, v2, dir, light);
-                    putVertex(builder, ms, x2, depth, positive ? y1 : y2, color, u2, v1, dir, light);
+                    putVertex(builder, pose, x1, depth, positive ? y1 : y2, color, u1, v1, dir, light);
+                    putVertex(builder, pose, x1, depth, positive ? y2 : y1, color, u1, v2, dir, light);
+                    putVertex(builder, pose, x2, depth, positive ? y2 : y1, color, u2, v2, dir, light);
+                    putVertex(builder, pose, x2, depth, positive ? y1 : y2, color, u2, v1, dir, light);
                 }
             }
         }
     }
 
-    private static void putVertex(VertexConsumer builder, PoseStack ms, float x, float y, float z, int color, float u,
+    private static void putVertex(VertexConsumer builder, PoseStack.Pose pose, float x, float y, float z, int color, float u,
                                   float v, Direction face, int light) {
 
         Vec3i normal = face.getUnitVec3i();
-        PoseStack.Pose peek = ms.last();
         int a = color >> 24 & 0xff;
         int r = color >> 16 & 0xff;
         int g = color >> 8 & 0xff;
         int b = color & 0xff;
 
-        builder.addVertex(peek.pose(), x, y, z)
+        builder.addVertex(pose.pose(), x, y, z)
                 .setColor(r, g, b, a)
                 .setUv(u, v)
                 .setOverlay(OverlayTexture.NO_OVERLAY)
                 .setLight(light)
-                .setNormal(peek, normal.getX(), normal.getY(), normal.getZ());
+                .setNormal(pose, normal.getX(), normal.getY(), normal.getZ());
+    }
+
+    private static void putVertex(VertexConsumer builder, PoseStack ms, float x, float y, float z, int color, float u,
+                                  float v, Direction face, int light) {
+        putVertex(builder, ms.last(), x, y, z, color, u, v, face, light);
     }
 
     public enum FluidTextureType {


### PR DESCRIPTION
## Summary
- render the tank fluid surface with the fluid sprite's atlas UVs instead of sampling the whole block atlas
- remove the extra horizontal pose translation so the fluid surface renders in the correct tank position
- validate with ./gradlew.bat compileJava

Closes #313