### PR TITLE
fix: ignore fluid components in accumulator recipes

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCachedCheck.java
@@ -6,6 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.salammoniacaccumulator;
 
 import com.klikli_dev.theurgy.content.recipe.AccumulationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerWithFluidRecipeInput;
+import com.klikli_dev.theurgy.content.storage.FluidStorageHelper;
 import com.klikli_dev.theurgy.util.LevelUtil;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
@@ -25,13 +26,33 @@ import java.util.Optional;
 class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<ItemHandlerWithFluidRecipeInput, AccumulationRecipe> {
 
     private final RecipeType<AccumulationRecipe> type;
-    private final RecipeManager.CachedCheck<ItemHandlerWithFluidRecipeInput, AccumulationRecipe> internal;
     @Nullable
     private ResourceKey<Recipe<?>> lastRecipe;
 
     public SalAmmoniacAccumulatorCachedCheck(RecipeType<AccumulationRecipe> type) {
         this.type = type;
-        this.internal = RecipeManager.createCheck(type);
+    }
+
+    private FluidStack normalizeFluid(FluidStack stack) {
+        if (stack.isEmpty() || stack.isComponentsPatchEmpty()) {
+            return stack;
+        }
+
+        return new FluidStack(stack.getFluid(), stack.getAmount());
+    }
+
+    private boolean matchesEvaporant(AccumulationRecipe recipe, FluidStack stack) {
+        return recipe.hasEvaporant() && recipe.evaporant().ingredient().test(this.normalizeFluid(stack));
+    }
+
+    private boolean matches(ItemHandlerWithFluidRecipeInput container, AccumulationRecipe recipe) {
+        var fluid = this.normalizeFluid(FluidStorageHelper.getFluidInTank(container.getTank(), 0));
+        boolean evaporantMatches = !recipe.hasEvaporant() || recipe.evaporant().test(fluid);
+        boolean soluteMatches =
+                container.getItem(0).isEmpty() && !recipe.hasSolute() ||
+                        recipe.hasSolute() && recipe.solute().test(container.getItem(0));
+
+        return soluteMatches && evaporantMatches;
     }
 
     private Optional<RecipeHolder<AccumulationRecipe>> getRecipeFor(ItemStack stack, ServerLevel level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
@@ -63,14 +84,14 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
                     @SuppressWarnings("unchecked")
                     var typedRecipe = (RecipeHolder<AccumulationRecipe>) recipe;
                     //test only the fluid without the (separate) solute item ingredient check that the recipe.matches() would.
-                    if (typedRecipe.value().hasEvaporant() && typedRecipe.value().evaporant().ingredient().test(stack)) {
+                    if (this.matchesEvaporant(typedRecipe.value(), stack)) {
                         return Optional.of(typedRecipe);
                     }
                 }
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().hasEvaporant() && entry.value().evaporant().ingredient().test(stack)).findFirst();
+        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matchesEvaporant(entry.value(), stack)).findFirst();
     }
 
     /**
@@ -106,11 +127,23 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
      */
     @Override
     public Optional<RecipeHolder<AccumulationRecipe>> getRecipeFor(ItemHandlerWithFluidRecipeInput container, ServerLevel level) {
-        var recipe = this.internal.getRecipeFor(container, level);
-        if (recipe.isPresent()) {
-            this.lastRecipe = recipe.get().id();
+        var recipeManager = level.getServer().getRecipeManager();
+        if (this.lastRecipe != null) {
+            var recipeOptional = recipeManager.byKey(this.lastRecipe);
+            if (recipeOptional.isPresent()) {
+                var recipe = recipeOptional.get();
+                if (recipe.value().getType() == this.type) {
+                    @SuppressWarnings("unchecked")
+                    var typedRecipe = (RecipeHolder<AccumulationRecipe>) recipe;
+                    if (this.matches(container, typedRecipe.value())) {
+                        return Optional.of(typedRecipe);
+                    }
+                }
+            }
         }
 
+        var recipe = LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matches(container, entry.value())).findFirst();
+        recipe.ifPresent(value -> this.lastRecipe = value.id());
         return recipe;
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCachedCheck.java
@@ -7,7 +7,6 @@ package com.klikli_dev.theurgy.content.apparatus.salammoniacaccumulator;
 import com.klikli_dev.theurgy.content.recipe.AccumulationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerWithFluidRecipeInput;
 import com.klikli_dev.theurgy.content.storage.FluidStorageHelper;
-import com.klikli_dev.theurgy.util.LevelUtil;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -41,16 +40,15 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
         return new FluidStack(stack.getFluid(), stack.getAmount());
     }
 
-    private boolean matchesEvaporant(AccumulationRecipe recipe, FluidStack stack) {
-        return recipe.hasEvaporant() && recipe.evaporant().ingredient().test(this.normalizeFluid(stack));
+    private boolean matchesEvaporant(AccumulationRecipe recipe, FluidStack normalizedStack) {
+        return recipe.hasEvaporant() && recipe.evaporant().ingredient().test(normalizedStack);
     }
 
-    private boolean matches(ItemHandlerWithFluidRecipeInput container, AccumulationRecipe recipe) {
-        var fluid = this.normalizeFluid(FluidStorageHelper.getFluidInTank(container.getTank(), 0));
-        boolean evaporantMatches = !recipe.hasEvaporant() || recipe.evaporant().test(fluid);
+    private boolean matches(ItemStack item, FluidStack normalizedFluid, AccumulationRecipe recipe) {
+        boolean evaporantMatches = !recipe.hasEvaporant() || recipe.evaporant().test(normalizedFluid);
         boolean soluteMatches =
-                container.getItem(0).isEmpty() && !recipe.hasSolute() ||
-                        recipe.hasSolute() && recipe.solute().test(container.getItem(0));
+                item.isEmpty() && !recipe.hasSolute() ||
+                        recipe.hasSolute() && recipe.solute().test(item);
 
         return soluteMatches && evaporantMatches;
     }
@@ -71,11 +69,12 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().hasSolute() && entry.value().solute().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().hasSolute() && entry.value().solute().test(stack)).findFirst();
     }
 
     private Optional<RecipeHolder<AccumulationRecipe>> getRecipeFor(FluidStack stack, ServerLevel level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
         var recipeManager = level.getServer().getRecipeManager();
+        var normalizedStack = this.normalizeFluid(stack);
         if (lastRecipe != null) {
             var recipeOptional = recipeManager.byKey(lastRecipe);
             if (recipeOptional.isPresent()) {
@@ -84,14 +83,14 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
                     @SuppressWarnings("unchecked")
                     var typedRecipe = (RecipeHolder<AccumulationRecipe>) recipe;
                     //test only the fluid without the (separate) solute item ingredient check that the recipe.matches() would.
-                    if (this.matchesEvaporant(typedRecipe.value(), stack)) {
+                    if (this.matchesEvaporant(typedRecipe.value(), normalizedStack)) {
                         return Optional.of(typedRecipe);
                     }
                 }
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matchesEvaporant(entry.value(), stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> this.matchesEvaporant(entry.value(), normalizedStack)).findFirst();
     }
 
     /**
@@ -128,6 +127,8 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
     @Override
     public Optional<RecipeHolder<AccumulationRecipe>> getRecipeFor(ItemHandlerWithFluidRecipeInput container, ServerLevel level) {
         var recipeManager = level.getServer().getRecipeManager();
+        var item = container.getItem(0);
+        var fluid = this.normalizeFluid(FluidStorageHelper.getFluidInTank(container.getTank(), 0));
         if (this.lastRecipe != null) {
             var recipeOptional = recipeManager.byKey(this.lastRecipe);
             if (recipeOptional.isPresent()) {
@@ -135,14 +136,14 @@ class SalAmmoniacAccumulatorCachedCheck implements RecipeManager.CachedCheck<Ite
                 if (recipe.value().getType() == this.type) {
                     @SuppressWarnings("unchecked")
                     var typedRecipe = (RecipeHolder<AccumulationRecipe>) recipe;
-                    if (this.matches(container, typedRecipe.value())) {
+                    if (this.matches(item, fluid, typedRecipe.value())) {
                         return Optional.of(typedRecipe);
                     }
                 }
             }
         }
 
-        var recipe = LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matches(container, entry.value())).findFirst();
+        var recipe = recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> this.matches(item, fluid, entry.value())).findFirst();
         recipe.ifPresent(value -> this.lastRecipe = value.id());
         return recipe;
     }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacAccumulatorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacAccumulatorGameTests.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.gametest;
 
 import com.klikli_dev.theurgy.content.apparatus.salammoniacaccumulator.SalAmmoniacAccumulatorBlockEntity;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
-import com.klikli_dev.theurgy.registry.FluidRegistry;
 import com.klikli_dev.theurgy.registry.ItemRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
@@ -16,7 +15,6 @@ import net.neoforged.neoforge.fluids.FluidStack;
 public class SalAmmoniacAccumulatorGameTests {
 
     private static final BlockPos ACCUMULATOR_POS = new BlockPos(2, 2, 2);
-
     // --- Placement & State ---
 
     public static void placementAndDefaultState(GameTestHelper helper) {
@@ -45,7 +43,8 @@ public class SalAmmoniacAccumulatorGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(ACCUMULATOR_POS, SalAmmoniacAccumulatorBlockEntity.class);
             var filled = blockEntity.waterTank.fill(
-                    new FluidStack(net.minecraft.world.level.material.Fluids.WATER, 1000), false
+                    new FluidStack(net.minecraft.world.level.material.Fluids.WATER, 1000),
+                    false
             );
             helper.assertTrue(filled == 1000, "Water tank should accept 1000mb of water");
             helper.assertTrue(blockEntity.waterTank.getFluidAmount() == 1000, "Water tank should contain 1000mb of water");


### PR DESCRIPTION
## Summary
- normalize Sal Ammoniac Accumulator evaporant matching so water with attached fluid components still matches plain water accumulation recipes
- keep the existing accumulator insert-water game test unchanged and verify the full existing game test suite passes

Closes #273

## Validation
- ./gradlew.bat --no-daemon compileJava
- ./gradlew.bat --no-daemon runGameTestServer --console=plain