### PR TITLE
fix: use indexed cached recipe lookups

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationCachedCheck.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.content.apparatus.calcinationoven;
 
 import com.klikli_dev.theurgy.content.recipe.CalcinationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerRecipeInput;
-import com.klikli_dev.theurgy.util.LevelUtil;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
@@ -42,7 +41,7 @@ class CalcinationCachedCheck implements RecipeManager.CachedCheck<ItemHandlerRec
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().sizedIngredient().ingredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().sizedIngredient().ingredient().test(stack)).findFirst();
     }
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCachedCheck.java
@@ -94,7 +94,7 @@ public class DigestionCachedCheck implements RecipeManager.CachedCheck<ItemHandl
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matchesRecipe(entry, input)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> this.matchesRecipe(entry, input)).findFirst();
     }
 
     private Optional<RecipeHolder<DigestionRecipe>> getRecipeFor(ItemStack stack, Level level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
@@ -110,7 +110,7 @@ public class DigestionCachedCheck implements RecipeManager.CachedCheck<ItemHandl
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getIngredients().stream().anyMatch(i -> i.test(stack))).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredients().stream().anyMatch(i -> i.test(stack))).findFirst();
     }
 
     private Optional<RecipeHolder<DigestionRecipe>> getRecipeFor(FluidStack stack, Level level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
@@ -126,7 +126,7 @@ public class DigestionCachedCheck implements RecipeManager.CachedCheck<ItemHandl
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getFluid().ingredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getFluid().ingredient().test(stack)).findFirst();
     }
 
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationCachedCheck.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.content.apparatus.distiller;
 
 import com.klikli_dev.theurgy.content.recipe.DistillationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerRecipeInput;
-import com.klikli_dev.theurgy.util.LevelUtil;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
@@ -32,7 +31,7 @@ class DistillationCachedCheck implements RecipeManager.CachedCheck<ItemHandlerRe
     }
 
     private Optional<RecipeHolder<DistillationRecipe>> getRecipeFor(ItemStack stack, ServerLevel level, @Nullable net.minecraft.resources.ResourceKey<net.minecraft.world.item.crafting.Recipe<?>> lastRecipe) {
-        var recipeManager = LevelUtil.getRecipeManager(level);
+        var recipeManager = level.getServer().getRecipeManager();
         if (lastRecipe != null) {
 
             var recipe = recipeManager.byKey(lastRecipe).orElse(null);
@@ -43,7 +42,7 @@ class DistillationCachedCheck implements RecipeManager.CachedCheck<ItemHandlerRe
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getIngredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredient().test(stack)).findFirst();
     }
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationCachedCheck.java
@@ -42,7 +42,7 @@ class DistillationCachedCheck implements RecipeManager.CachedCheck<ItemHandlerRe
             }
         }
 
-        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredient().ingredient().test(stack)).findFirst();
     }
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCachedCheck.java
@@ -96,7 +96,7 @@ public class FermentationCachedCheck implements RecipeManager.CachedCheck<ItemHa
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> this.matchesRecipe(entry, input)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> this.matchesRecipe(entry, input)).findFirst();
     }
 
     private Optional<RecipeHolder<FermentationRecipe>> getRecipeFor(ItemStack stack, Level level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
@@ -112,7 +112,7 @@ public class FermentationCachedCheck implements RecipeManager.CachedCheck<ItemHa
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getIngredients().stream().anyMatch(i -> i.test(stack))).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredients().stream().anyMatch(i -> i.test(stack))).findFirst();
     }
 
     private Optional<RecipeHolder<FermentationRecipe>> getRecipeFor(FluidStack stack, Level level, @Nullable ResourceKey<Recipe<?>> lastRecipe) {
@@ -128,7 +128,7 @@ public class FermentationCachedCheck implements RecipeManager.CachedCheck<ItemHa
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getFluid().ingredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getFluid().ingredient().test(stack)).findFirst();
     }
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCachedCheck.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCachedCheck.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.content.apparatus.liquefactioncauldron;
 
 import com.klikli_dev.theurgy.content.recipe.LiquefactionRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerWithFluidRecipeInput;
-import com.klikli_dev.theurgy.util.LevelUtil;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -49,7 +48,7 @@ class LiquefactionCachedCheck implements RecipeManager.CachedCheck<ItemHandlerWi
             }
         }
 
-        return LevelUtil.getRecipesByType(recipeManager, this.type).stream().filter((entry) -> entry.value().getIngredient().test(stack)).findFirst();
+        return recipeManager.recipeMap().byType(this.type).stream().filter((entry) -> entry.value().getIngredient().test(stack)).findFirst();
     }
 
     /**


### PR DESCRIPTION
## Summary
- switch the remaining apparatus cached checks from all-recipes scans to the recipe manager's indexed ecipeMap().byType(...) lookup
- keep behavior unchanged while reducing per-lookup work in liquefaction, distillation, calcination, fermentation, and digestion cached checks

## Validation
- ./gradlew.bat --no-daemon compileJava
- ./gradlew.bat --no-daemon runGameTestServer --console=plain