### PR TITLE
fix: only fire recipe monitor onContentTypeChanged if item is different

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/storage/MonitoredItemStackHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/storage/MonitoredItemStackHandler.java
@@ -80,7 +80,7 @@ public abstract class MonitoredItemStackHandler extends ItemStacksResourceHandle
             var newStack = this.getStackInSlot(slot);
 
             this.onInsertItem(slot, oldStack, newStack, toInsert, remaining);
-            if (remaining != toInsert) {
+            if (!ItemStack.isSameItemSameComponents(newStack, oldStack)) {
                 this.onContentTypeChanged(slot, oldStack, newStack);
             }
             return remaining;


### PR DESCRIPTION
Fixes an annoying bug where the crafting time of an apparatus would be constantly reset if items were inserted while it was crafting. (for example, a hopper constantly feeding a Mercury Distiller with cobblestone)

This issue was also present on 1.21.1.