### PR TITLE
feat: show in-world hud for item and fluid containers

### DIFF
--- a/src/generated/resources/assets/theurgy/lang/en_us.json
+++ b/src/generated/resources/assets/theurgy/lang/en_us.json
@@ -2739,6 +2739,7 @@
   "theurgy.jei.misc.mercury_flux": "Mercury Flux: %s",
   "theurgy.jei.misc.source_pedestal_count": "%sx",
   "theurgy.jei.misc.source_sulfur.tooltip": "The Target Sulfur will not be consumed!\nYou can retrieve it after crafting is complete.",
+  "theurgy.misc.amount_capacity_millibuckets": "%1$s / %2$smB",
   "theurgy.misc.empty": "Empty",
   "theurgy.misc.unit.millibuckets": "%smB",
   "theurgy.subtitle.tuning_fork": "Using Divination Rod",

--- a/src/generated/resources/assets/theurgy/lang/en_us.json
+++ b/src/generated/resources/assets/theurgy/lang/en_us.json
@@ -2739,6 +2739,7 @@
   "theurgy.jei.misc.mercury_flux": "Mercury Flux: %s",
   "theurgy.jei.misc.source_pedestal_count": "%sx",
   "theurgy.jei.misc.source_sulfur.tooltip": "The Target Sulfur will not be consumed!\nYou can retrieve it after crafting is complete.",
+  "theurgy.misc.empty": "Empty",
   "theurgy.misc.unit.millibuckets": "%smB",
   "theurgy.subtitle.tuning_fork": "Using Divination Rod",
   "theurgytheurgy.alchemical_tier.abundant": "Abundant",

--- a/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
+++ b/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
@@ -109,6 +109,7 @@ public class TheurgyConstants {
         public static class Misc {
             public static final String PREFIX = Theurgy.MODID + ".misc.";
 
+            public static final String EMPTY = PREFIX + "empty";
             public static final String UNIT_MILLIBUCKETS = PREFIX + "unit.millibuckets";
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
+++ b/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
@@ -109,6 +109,7 @@ public class TheurgyConstants {
         public static class Misc {
             public static final String PREFIX = Theurgy.MODID + ".misc.";
 
+            public static final String AMOUNT_CAPACITY_MILLIBUCKETS = PREFIX + "amount_capacity_millibuckets";
             public static final String EMPTY = PREFIX + "empty";
             public static final String UNIT_MILLIBUCKETS = PREFIX + "unit.millibuckets";
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDProvider.java
@@ -16,6 +16,10 @@ public interface InWorldHUDProvider {
 
     boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
 
+    default boolean activatesHUD() {
+        return true;
+    }
+
     default void appendClientData(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -83,16 +83,27 @@ public class InWorldHUDRegistry {
         BlockState state = level.getBlockState(pos);
         BlockEntity blockEntity = level.getBlockEntity(pos);
 
-        List<InWorldHUDProvider> applicableBlockProviders = BLOCK_PROVIDERS.getOrDefault(state.getBlock(), List.of()).stream()
-                .filter(provider -> provider.applies(level, pos, state, blockEntity))
-                .toList();
+        List<InWorldHUDProvider> applicableBlockProviders = new ArrayList<>();
+        boolean hasActivatingProvider = false;
 
-        List<InWorldHUDProvider> applicableGenericProviders = GENERIC_PROVIDERS.stream()
-                .filter(provider -> provider.applies(level, pos, state, blockEntity))
-                .toList();
+        for (InWorldHUDProvider provider : BLOCK_PROVIDERS.getOrDefault(state.getBlock(), List.of())) {
+            if (!provider.applies(level, pos, state, blockEntity)) {
+                continue;
+            }
 
-        boolean hasActivatingProvider = applicableBlockProviders.stream().anyMatch(InWorldHUDProvider::activatesHUD)
-                || applicableGenericProviders.stream().anyMatch(InWorldHUDProvider::activatesHUD);
+            applicableBlockProviders.add(provider);
+            hasActivatingProvider |= provider.activatesHUD();
+        }
+
+        List<InWorldHUDProvider> applicableGenericProviders = new ArrayList<>();
+        for (InWorldHUDProvider provider : GENERIC_PROVIDERS) {
+            if (!provider.applies(level, pos, state, blockEntity)) {
+                continue;
+            }
+
+            applicableGenericProviders.add(provider);
+            hasActivatingProvider |= provider.activatesHUD();
+        }
 
         if (!hasActivatingProvider) {
             return List.of();

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -4,10 +4,10 @@
 
 package com.klikli_dev.theurgy.content.render.inworldhud;
 
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.BlockTitleInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.FluidStorageInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.ItemStorageInWorldHUDProvider;
-import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryCatalystInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxStorageInWorldHUDProvider;
-import com.klikli_dev.theurgy.registry.BlockRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -33,8 +33,9 @@ public class InWorldHUDRegistry {
             return;
         }
 
-        registerBlockProvider(BlockRegistry.MERCURY_CATALYST.get(), new MercuryCatalystInWorldHUDProvider());
+        registerGenericProvider(new BlockTitleInWorldHUDProvider());
         registerGenericProvider(new MercuryFluxStorageInWorldHUDProvider());
+        registerGenericProvider(new FluidStorageInWorldHUDProvider());
         registerGenericProvider(new ItemStorageInWorldHUDProvider());
 
         defaultsRegistered = true;
@@ -86,12 +87,19 @@ public class InWorldHUDRegistry {
                 .filter(provider -> provider.applies(level, pos, state, blockEntity))
                 .toList();
 
-        if (applicableBlockProviders.isEmpty()) {
+        List<InWorldHUDProvider> applicableGenericProviders = GENERIC_PROVIDERS.stream()
+                .filter(provider -> provider.applies(level, pos, state, blockEntity))
+                .toList();
+
+        boolean hasActivatingProvider = applicableBlockProviders.stream().anyMatch(InWorldHUDProvider::activatesHUD)
+                || applicableGenericProviders.stream().anyMatch(InWorldHUDProvider::activatesHUD);
+
+        if (!hasActivatingProvider) {
             return List.of();
         }
 
         List<InWorldHUDProvider> result = new ArrayList<>(applicableBlockProviders);
-        GENERIC_PROVIDERS.stream().filter(provider -> provider.applies(level, pos, state, blockEntity)).forEach(result::add);
+        result.addAll(applicableGenericProviders);
         return result;
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/BlockTitleInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/BlockTitleInWorldHUDProvider.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.Theurgy;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import com.klikli_dev.theurgy.registry.CapabilityRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockTitleInWorldHUDProvider implements InWorldHUDProvider {
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return Theurgy.MODID.equals(BuiltInRegistries.BLOCK.getKey(state.getBlock()).getNamespace())
+                && (level.getCapability(CapabilityRegistry.ITEM_HANDLER, pos, state, blockEntity, null) != null
+                || level.getCapability(CapabilityRegistry.FLUID_HANDLER, pos, state, blockEntity, null) != null);
+    }
+
+    @Override
+    public void appendClientData(InWorldHUDBuilder builder, Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        builder.setTitleIfAbsent(state.getBlock().getName());
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/BlockTitleInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/BlockTitleInWorldHUDProvider.java
@@ -21,7 +21,8 @@ public class BlockTitleInWorldHUDProvider implements InWorldHUDProvider {
     public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
         return Theurgy.MODID.equals(BuiltInRegistries.BLOCK.getKey(state.getBlock()).getNamespace())
                 && (level.getCapability(CapabilityRegistry.ITEM_HANDLER, pos, state, blockEntity, null) != null
-                || level.getCapability(CapabilityRegistry.FLUID_HANDLER, pos, state, blockEntity, null) != null);
+                || level.getCapability(CapabilityRegistry.FLUID_HANDLER, pos, state, blockEntity, null) != null
+                || level.getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, pos, state, blockEntity, null) != null);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
@@ -44,7 +44,7 @@ public class FluidStorageInWorldHUDProvider implements InWorldHUDProvider {
             var fluidStack = FluidStorageHelper.getFluidInTank(fluidHandler, tank);
             int amount = fluidStack.getAmount();
             int capacity = FluidStorageHelper.getTankCapacity(fluidHandler, tank);
-            var displayName = fluidStack.isEmpty() ? Component.translatable("container.empty") : fluidStack.getHoverName();
+            var displayName = fluidStack.isEmpty() ? Component.translatable(TheurgyConstants.I18n.Misc.EMPTY) : fluidStack.getHoverName();
             var amountText = Component.translatable(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, amount + " / " + capacity);
 
             builder.addLine(Component.empty()

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
@@ -45,7 +45,7 @@ public class FluidStorageInWorldHUDProvider implements InWorldHUDProvider {
             int amount = fluidStack.getAmount();
             int capacity = FluidStorageHelper.getTankCapacity(fluidHandler, tank);
             var displayName = fluidStack.isEmpty() ? Component.translatable(TheurgyConstants.I18n.Misc.EMPTY) : fluidStack.getHoverName();
-            var amountText = Component.translatable(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, amount + " / " + capacity);
+            var amountText = Component.translatable(TheurgyConstants.I18n.Misc.AMOUNT_CAPACITY_MILLIBUCKETS, amount, capacity);
 
             builder.addLine(Component.empty()
                     .append(displayName)

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/FluidStorageInWorldHUDProvider.java
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.TheurgyConstants;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import com.klikli_dev.theurgy.content.storage.FluidStorageHelper;
+import com.klikli_dev.theurgy.registry.CapabilityRegistry;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+import org.jetbrains.annotations.Nullable;
+
+public class FluidStorageInWorldHUDProvider implements InWorldHUDProvider {
+
+    @Override
+    public boolean activatesHUD() {
+        return false;
+    }
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return level.getCapability(CapabilityRegistry.FLUID_HANDLER, pos, state, blockEntity, null) != null;
+    }
+
+    @Override
+    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        ResourceHandler<FluidResource> fluidHandler = level.getCapability(CapabilityRegistry.FLUID_HANDLER, pos, state, blockEntity, null);
+        if (fluidHandler == null) {
+            return;
+        }
+
+        for (int tank = 0; tank < FluidStorageHelper.getTanks(fluidHandler); tank++) {
+            var fluidStack = FluidStorageHelper.getFluidInTank(fluidHandler, tank);
+            int amount = fluidStack.getAmount();
+            int capacity = FluidStorageHelper.getTankCapacity(fluidHandler, tank);
+            var displayName = fluidStack.isEmpty() ? Component.translatable("container.empty") : fluidStack.getHoverName();
+            var amountText = Component.translatable(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, amount + " / " + capacity);
+
+            builder.addLine(Component.empty()
+                    .append(displayName)
+                    .append(Component.literal(" ("))
+                    .append(amountText)
+                    .append(Component.literal(")"))
+                    .withStyle(ChatFormatting.GRAY));
+        }
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/ItemStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/ItemStorageInWorldHUDProvider.java
@@ -21,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
 public class ItemStorageInWorldHUDProvider implements InWorldHUDProvider {
 
     @Override
+    public boolean activatesHUD() {
+        return false;
+    }
+
+    @Override
     public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
         return level.getCapability(CapabilityRegistry.ITEM_HANDLER, pos, state, blockEntity, null) != null;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxStorageInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxStorageInWorldHUDProvider.java
@@ -21,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
 public class MercuryFluxStorageInWorldHUDProvider implements InWorldHUDProvider {
 
     @Override
+    public boolean activatesHUD() {
+        return false;
+    }
+
+    @Override
     public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
         return level.getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, pos, state, blockEntity, null) != null;
     }

--- a/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
@@ -82,6 +82,7 @@ public class ENUSProvider extends AbstractModonomiconLanguageProvider implements
                 ChatFormatting.GRAY + "usage" +
                 ChatFormatting.GOLD + "]");
 
+        this.add(TheurgyConstants.I18n.Misc.AMOUNT_CAPACITY_MILLIBUCKETS, "%1$s / %2$smB");
         this.add(TheurgyConstants.I18n.Misc.EMPTY, "Empty");
         this.add(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, "%smB");
     }

--- a/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
@@ -82,6 +82,7 @@ public class ENUSProvider extends AbstractModonomiconLanguageProvider implements
                 ChatFormatting.GRAY + "usage" +
                 ChatFormatting.GOLD + "]");
 
+        this.add(TheurgyConstants.I18n.Misc.EMPTY, "Empty");
         this.add(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, "%smB");
     }
 


### PR DESCRIPTION
## Summary
- extend the in-world HUD beyond the Mercury Catalyst to any Theurgy block with item or fluid storage
- add generic title and fluid storage providers while keeping item, fluid, and mercury-flux providers as supplemental HUD data
- update HUD activation logic so generic providers can drive display for supported Theurgy containers and validate with `./gradlew.bat compileJava`