### PR TITLE
feat(jade): update mercury flux provider to support jade 26.1 API structure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ sourceSets {
     main {
         java {
             // Temporarily disable occultism integration implementation until 1.21.3 artifact is available
-            exclude '**/integration/occultism/impl/**'
+//            exclude '**/integration/occultism/impl/**'
             exclude '**/AlmostUnifiedIntegrationImpl.java'
-            exclude '**/jade/**/*.java'
+//            exclude '**/jade/**/*.java'
             exclude '**/jei/**/*.java'
             exclude '**/emi/**/*.java'
         }
@@ -152,8 +152,8 @@ dependencies {
     implementation ("com.klikli_dev:modonomicon-${minecraft_version}-neoforge:${modonomicon_version}") {transitive=false}
 
     //occultism
-//    compileOnly ("com.klikli_dev:occultism-${minecraft_version}-neoforge:${occultism_version}") {transitive=false}
-//    localRuntime ("com.klikli_dev:occultism-${minecraft_version}-neoforge:${occultism_version}")
+    compileOnly ("com.klikli_dev:occultism-${minecraft_version}-neoforge:${occultism_version}") {transitive=false}
+    localRuntime ("com.klikli_dev:occultism-${minecraft_version}-neoforge:${occultism_version}")
 
     //Jade (Hwyla/Waila)
     implementation ("maven.modrinth:jade:${jade_version}+neoforge") {transitive=false}
@@ -177,6 +177,17 @@ repositories {
         url = 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
         content {
             includeGroup "com.geckolib"
+        }
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ dependencies {
 //    localRuntime ("com.klikli_dev:occultism-${minecraft_version}-neoforge:${occultism_version}")
 
     //Jade (Hwyla/Waila)
-//    implementation ("maven.modrinth:jade:${jade_version}+neoforge") {transitive=false}
+    implementation ("maven.modrinth:jade:${jade_version}+neoforge") {transitive=false}
 
     //EMI
 //    compileOnly ("dev.emi:emi-neoforge:${emi_version}+${minecraft_version_major}:api") {transitive=false}

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ mod_description=An open-source magic mod built around classical alchemy to repli
 
 jei_version=19.8.2.99
 modonomicon_version=1.130.0
-occultism_version=1.151.3
+occultism_version=1.208.2
 almost_unified_version=0.5.0
 geckolib_version=5.5
 jade_version=26.0.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,5 +33,5 @@ modonomicon_version=1.130.0
 occultism_version=1.151.3
 almost_unified_version=0.5.0
 geckolib_version=5.5
-jade_version=15.1.6
+jade_version=26.0.6
 emi_version=1.1.12

--- a/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
+++ b/src/main/java/com/klikli_dev/theurgy/TheurgyConstants.java
@@ -110,6 +110,7 @@ public class TheurgyConstants {
             public static final String PREFIX = Theurgy.MODID + ".misc.";
 
             public static final String AMOUNT_CAPACITY_MILLIBUCKETS = PREFIX + "amount_capacity_millibuckets";
+            public static final String CRAFTING_PROGRESS = PREFIX + "crafting_progress";
             public static final String EMPTY = PREFIX + "empty";
             public static final String UNIT_MILLIBUCKETS = PREFIX + "unit.millibuckets";
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/render/CalcinationOvenModel.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/render/CalcinationOvenModel.java
@@ -25,6 +25,6 @@ public class CalcinationOvenModel<T extends GeoAnimatable> extends GeoModel<T> {
 
     @Override
     public @NonNull Identifier getAnimationResource(T animatable) {
-        return Theurgy.loc("block/calcination_oven.animation.json");
+        return Theurgy.loc("block/calcination_oven");
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/render/DistillerModel.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/render/DistillerModel.java
@@ -24,6 +24,6 @@ public class DistillerModel<T extends GeoAnimatable> extends GeoModel<T> {
 
     @Override
     public @NonNull Identifier getAnimationResource(T animatable) {
-        return Theurgy.loc("block/distiller.animation.json");
+        return Theurgy.loc("block/distiller");
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsitemconnector/extractor/LogisticsItemExtractorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsitemconnector/extractor/LogisticsItemExtractorBehaviour.java
@@ -145,7 +145,7 @@ public class LogisticsItemExtractorBehaviour extends ExtractorNodeBehaviour<Reso
                 //and insertion
                 ItemStack inserted = ItemStorageHelper.insertItemStacked(insertCap, extractStack, true);
                 //TODO(optimization): does it make sense to cache "failed to insert" stacks?
-                //      1) use our own insert code instead of ItemHandlerHelper.insertItemStacked that the first sequence of full slots?
+                //      1) use a custom insert path instead of ItemStorageHelper.insertItemStacked that tries the first sequence of full slots?
                 //      2) store itemstack + component (but not count) that failed to insert at all (not even 1 inserted in entire target container)
 
                 //then if anything was inserted during the simulation, perform the real extraction and insertion

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/crafting/CraftingBehaviour.java
@@ -53,6 +53,22 @@ public abstract class CraftingBehaviour<W extends RecipeInput, R extends Recipe<
         return this.couldCraftLastTick;
     }
 
+    public int progress() {
+        return this.progress;
+    }
+
+    public int totalTime() {
+        return this.totalTime;
+    }
+
+    public int progressPercent() {
+        if (this.totalTime <= 0) {
+            return 0;
+        }
+
+        return Math.clamp(this.progress * 100 / this.totalTime, 0, 100);
+    }
+
     public void readNetwork(ValueInput input) {
         this.isProcessing = input.getBooleanOr("isProcessing", false);
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -5,9 +5,11 @@
 package com.klikli_dev.theurgy.content.render.inworldhud;
 
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.BlockTitleInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.CalcinationOvenCraftingProgressInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.FluidStorageInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.ItemStorageInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxStorageInWorldHUDProvider;
+import com.klikli_dev.theurgy.registry.BlockRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -37,6 +39,7 @@ public class InWorldHUDRegistry {
         registerGenericProvider(new MercuryFluxStorageInWorldHUDProvider());
         registerGenericProvider(new FluidStorageInWorldHUDProvider());
         registerGenericProvider(new ItemStorageInWorldHUDProvider());
+        registerBlockProvider(BlockRegistry.CALCINATION_OVEN.get(), new CalcinationOvenCraftingProgressInWorldHUDProvider());
 
         defaultsRegistered = true;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/CalcinationOvenCraftingProgressInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/CalcinationOvenCraftingProgressInWorldHUDProvider.java
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.content.render.inworldhud.provider;
+
+import com.klikli_dev.theurgy.TheurgyConstants;
+import com.klikli_dev.theurgy.content.apparatus.calcinationoven.CalcinationOvenBlock;
+import com.klikli_dev.theurgy.content.apparatus.calcinationoven.CalcinationOvenBlockEntity;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
+import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import org.jetbrains.annotations.Nullable;
+
+public class CalcinationOvenCraftingProgressInWorldHUDProvider implements InWorldHUDProvider {
+
+    private static final int BAR_WIDTH = 10;
+    private static final String FILLED_SEGMENT = "█";
+    private static final String EMPTY_SEGMENT = "░";
+
+    @Override
+    public boolean activatesHUD() {
+        return false;
+    }
+
+    @Override
+    public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        return state.getBlock() instanceof CalcinationOvenBlock;
+    }
+
+    @Override
+    public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        CalcinationOvenBlockEntity oven = this.getBlockEntity(level, pos, state, blockEntity);
+        if (oven == null || !oven.craftingBehaviour().isProcessing()) {
+            return;
+        }
+
+        int progressPercent = oven.craftingBehaviour().progressPercent();
+
+        builder.addLine(Component.translatable(
+                TheurgyConstants.I18n.Misc.CRAFTING_PROGRESS,
+                Component.literal(this.progressBar(progressPercent)).withStyle(ChatFormatting.GREEN),
+                progressPercent
+        ).withStyle(ChatFormatting.GRAY));
+    }
+
+    private String progressBar(int progressPercent) {
+        int filledSegments = Math.clamp(progressPercent * BAR_WIDTH / 100, 0, BAR_WIDTH);
+        return FILLED_SEGMENT.repeat(filledSegments) + EMPTY_SEGMENT.repeat(BAR_WIDTH - filledSegments);
+    }
+
+    private @Nullable CalcinationOvenBlockEntity getBlockEntity(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        if (blockEntity instanceof CalcinationOvenBlockEntity oven) {
+            return oven;
+        }
+
+        if (state.hasProperty(CalcinationOvenBlock.HALF) && state.getValue(CalcinationOvenBlock.HALF) == DoubleBlockHalf.UPPER) {
+            BlockEntity lowerBlockEntity = level.getBlockEntity(pos.below());
+            if (lowerBlockEntity instanceof CalcinationOvenBlockEntity oven) {
+                return oven;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/lang/ENUSProvider.java
@@ -83,6 +83,7 @@ public class ENUSProvider extends AbstractModonomiconLanguageProvider implements
                 ChatFormatting.GOLD + "]");
 
         this.add(TheurgyConstants.I18n.Misc.AMOUNT_CAPACITY_MILLIBUCKETS, "%1$s / %2$smB");
+        this.add(TheurgyConstants.I18n.Misc.CRAFTING_PROGRESS, "Crafting: %1$s %2$s%%");
         this.add(TheurgyConstants.I18n.Misc.EMPTY, "Empty");
         this.add(TheurgyConstants.I18n.Misc.UNIT_MILLIBUCKETS, "%smB");
     }

--- a/src/main/java/com/klikli_dev/theurgy/integration/jade/JadePlugin.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jade/JadePlugin.java
@@ -4,21 +4,29 @@
 
 package com.klikli_dev.theurgy.integration.jade;
 
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
 import snownee.jade.api.WailaPlugin;
+import snownee.jade.api.view.IServerExtensionProvider;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.EnergyView;
+import net.minecraft.nbt.CompoundTag;
 
 @WailaPlugin
 public class JadePlugin implements IWailaPlugin {
     @Override
+    @SuppressWarnings("unchecked")
     public void register(IWailaCommonRegistration registration) {
-        registration.registerEnergyStorage(MercuryFluxEnergyProvider.get(), BlockEntity.class);
+        registration.registerEnergyStorage((IServerExtensionProvider) (Object) MercuryFluxEnergyProvider.get(), BlockEntity.class);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void registerClient(IWailaClientRegistration registration) {
-        registration.registerEnergyStorageClient(MercuryFluxEnergyProvider.get());
+        registration.registerBlockComponent(MercuryFluxEnergyProvider.Client.INSTANCE, Block.class);
+        registration.registerEnergyStorageClient((IClientExtensionProvider) (Object) MercuryFluxEnergyProvider.get());
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
@@ -6,12 +6,17 @@ package com.klikli_dev.theurgy.integration.jade;
 
 import com.klikli_dev.theurgy.Theurgy;
 import com.klikli_dev.theurgy.registry.CapabilityRegistry;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
 import snownee.jade.api.Accessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.config.IPluginConfig;
 import snownee.jade.api.view.*;
-import snownee.jade.util.CommonProxy;
 
 import java.util.List;
 import java.util.Objects;
@@ -25,26 +30,31 @@ public class MercuryFluxEnergyProvider implements IServerExtensionProvider<Compo
         return instance;
     }
 
-    public static @Nullable List<ViewGroup<CompoundTag>> wrapMercuryFluxStorage(Accessor<?> accessor) {
-        var storage = CommonProxy.getDefaultStorage(accessor, CapabilityRegistry.MERCURY_FLUX_HANDLER, null);
+    public static @Nullable List<ViewGroup<CompoundTag>> wrapMercuryFluxStorage(BlockEntity blockEntity) {
+        var storage = blockEntity.getLevel().getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, blockEntity.getBlockPos(), blockEntity.getBlockState(), blockEntity, null);
         if (storage != null) {
-            ViewGroup<CompoundTag> group = new ViewGroup(List.of(EnergyView.of(storage.getEnergyStored(), storage.getMaxEnergyStored())));
-            group.getExtraData().putString("Unit", "MF");
+            CompoundTag tag = new CompoundTag();
+            tag.putLong("cur", storage.getEnergyStored());
+            tag.putLong("max", storage.getMaxEnergyStored());
+            tag.putString("unit", "MF");
+            ViewGroup<CompoundTag> group = new ViewGroup<>(List.of(tag));
             return List.of(group);
         } else {
             return null;
         }
     }
 
-    public static boolean hasDefaultMercuryFluxStorage(Accessor<?> accessor) {
-        return CommonProxy.hasDefaultStorage(accessor, CapabilityRegistry.MERCURY_FLUX_HANDLER, null);
-    }
-
     @Override
+    @SuppressWarnings("unchecked")
     public List<ClientViewGroup<EnergyView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<CompoundTag>> groups) {
         return groups.stream().map($ -> {
-            String unit = $.getExtraData().getString("Unit");
-            return new ClientViewGroup<>($.views.stream().map(tag -> EnergyView.read(tag, unit)).filter(Objects::nonNull).toList());
+            List<EnergyView> views = $.views.stream().map(tag -> {
+                long cur = tag.getLong("cur").orElse(0L);
+                long max = tag.getLong("max").orElse(0L);
+                String unit = tag.getString("unit").orElse("MF");
+                return EnergyView.read(new EnergyView.Data(cur, max), unit);
+            }).filter(Objects::nonNull).toList();
+            return new ClientViewGroup<>(views);
         }).toList();
     }
 
@@ -55,10 +65,22 @@ public class MercuryFluxEnergyProvider implements IServerExtensionProvider<Compo
 
     @Override
     public @Nullable List<ViewGroup<CompoundTag>> getGroups(Accessor<?> accessor) {
-        return wrapMercuryFluxStorage(accessor);
+        if (accessor instanceof BlockAccessor blockAccessor) {
+            return wrapMercuryFluxStorage(blockAccessor.getBlockEntity());
+        }
+        return null;
     }
 
-    public boolean shouldRequestData(Accessor<?> accessor) {
-        return hasDefaultMercuryFluxStorage(accessor);
+    public enum Client implements IBlockComponentProvider {
+        INSTANCE;
+
+        @Override
+        public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        }
+
+        @Override
+        public Identifier getUid() {
+            return ID;
+        }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/integration/occultism/impl/OccultismIntegrationImpl.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/occultism/impl/OccultismIntegrationImpl.java
@@ -8,19 +8,20 @@ import com.klikli_dev.occultism.common.misc.ItemStackKey;
 import com.klikli_dev.occultism.common.misc.MapItemStackHandler;
 import com.klikli_dev.theurgy.content.behaviour.filter.Filter;
 import com.klikli_dev.theurgy.content.behaviour.filter.ListFilter;
+import com.klikli_dev.theurgy.content.storage.ItemStorageHelper;
 import com.klikli_dev.theurgy.integration.occultism.OccultismIntegration;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.neoforged.fml.ModList;
-import net.neoforged.neoforge.items.IItemHandler;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
 
 public class OccultismIntegrationImpl implements OccultismIntegration {
     public boolean isLoaded() {
         return ModList.get().isLoaded("occultism");
     }
 
-    public boolean tryPerformStorageActuatorExtraction(Level level, IItemHandler extractCap, Filter extractFilter, IItemHandler insertCap, Filter insertFilter, int extractionAmount) {
+    public boolean tryPerformStorageActuatorExtraction(Level level, ResourceHandler<ItemResource> extractCap, Filter extractFilter, ResourceHandler<ItemResource> insertCap, Filter insertFilter, int extractionAmount) {
         if (!this.isLoaded())
             return false;
 
@@ -29,7 +30,7 @@ public class OccultismIntegrationImpl implements OccultismIntegration {
 
     public static class OccultismHelper {
 
-        public static boolean tryPerformStorageActuatorExtraction(Level level, IItemHandler extractCap, Filter extractFilter, IItemHandler insertCap, Filter insertFilter, int extractionAmount) {
+        public static boolean tryPerformStorageActuatorExtraction(Level level, ResourceHandler<ItemResource> extractCap, Filter extractFilter, ResourceHandler<ItemResource> insertCap, Filter insertFilter, int extractionAmount) {
 
             if (!(extractCap instanceof MapItemStackHandler mapItemStackHandler) || !(extractFilter instanceof ListFilter listFilter))
                 return false;
@@ -41,7 +42,7 @@ public class OccultismIntegrationImpl implements OccultismIntegration {
 
         }
 
-        protected static boolean performExtraction(Level level, MapItemStackHandler extractCap, ListFilter extractFilter, IItemHandler insertCap, Filter insertFilter, int extractionAmount) {
+        protected static boolean performExtraction(Level level, MapItemStackHandler extractCap, ListFilter extractFilter, ResourceHandler<ItemResource> insertCap, Filter insertFilter, int extractionAmount) {
             var filterItems = extractFilter.filterItems();
 
             for (var filterItem : filterItems) {
@@ -53,10 +54,10 @@ public class OccultismIntegrationImpl implements OccultismIntegration {
                                 : extractCap.extractItemIgnoreComponents(key.stack(), extractionAmount, true);
 
                 if (!extractStack.isEmpty() && insertFilter.test(level, extractStack)) {
-                    var inserted = ItemHandlerHelper.insertItemStacked(insertCap, extractStack, true);
+                    var inserted = ItemStorageHelper.insertItemStacked(insertCap, extractStack, true);
 
                     if (inserted.getCount() != extractStack.getCount()) {
-                        ItemStack remaining = ItemHandlerHelper.insertItemStacked(insertCap, extractStack, false);
+                        ItemStack remaining = ItemStorageHelper.insertItemStacked(insertCap, extractStack, false);
                         extractCap.extractItem(
                                 //if we ignore data components, we build a new key from the actual extracted stack
                                 extractFilter.shouldRespectDataComponents() ? key : ItemStackKey.of(extractStack),

--- a/src/main/java/com/klikli_dev/theurgy/registry/ItemRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/registry/ItemRegistry.java
@@ -193,9 +193,9 @@ public class ItemRegistry {
     public static final DeferredItem<BlockItem> MERCURY_CATALYST =
             ITEMS.registerItem("mercury_catalyst", p -> new BlockItem(BlockRegistry.MERCURY_CATALYST.get(), p.useBlockDescriptionPrefix()));
     public static final DeferredItem<CaloricFluxEmitterBlockItem> CALORIC_FLUX_EMITTER =
-            ITEMS.registerItem("caloric_flux_emitter", p -> new CaloricFluxEmitterBlockItem(BlockRegistry.CALORIC_FLUX_EMITTER.get(), p));
+            ITEMS.registerItem("caloric_flux_emitter", p -> new CaloricFluxEmitterBlockItem(BlockRegistry.CALORIC_FLUX_EMITTER.get(), p.useBlockDescriptionPrefix()));
     public static final DeferredItem<SulfuricFluxEmitterBlockItem> SULFURIC_FLUX_EMITTER =
-            ITEMS.registerItem("sulfuric_flux_emitter", p -> new SulfuricFluxEmitterBlockItem(BlockRegistry.SULFURIC_FLUX_EMITTER.get(), p));
+            ITEMS.registerItem("sulfuric_flux_emitter", p -> new SulfuricFluxEmitterBlockItem(BlockRegistry.SULFURIC_FLUX_EMITTER.get(), p.useBlockDescriptionPrefix()));
 
     public static final DeferredItem<BlockItem> REFORMATION_SOURCE_PEDESTAL =
             ITEMS.registerItem("reformation_source_pedestal", p -> new BlockItem(BlockRegistry.REFORMATION_SOURCE_PEDESTAL.get(), p.useBlockDescriptionPrefix()));


### PR DESCRIPTION
## Summary
- Updated MercuryFluxEnergyProvider to support Jade's 26.1 data structures (EnergyView.Data) while maintaining CompoundTag based transport due to local Jade version constraints.
- Updated JadePlugin registration to use the new pattern for block components and energy storage.
- Preserved MF (Mercury Flux) unit semantics.