### PR TITLE
fix: correct flux emitter model rotations

### DIFF
--- a/src/generated/resources/assets/theurgy/blockstates/caloric_flux_emitter.json
+++ b/src/generated/resources/assets/theurgy/blockstates/caloric_flux_emitter.json
@@ -3,7 +3,7 @@
     {
       "apply": {
         "model": "theurgy:block/caloric_flux_emitter",
-        "x": 90
+        "x": 180
       },
       "when": {
         "facing": "down"
@@ -11,16 +11,16 @@
     },
     {
       "apply": {
-        "model": "theurgy:block/caloric_flux_emitter",
-        "y": 90
+        "model": "theurgy:block/caloric_flux_emitter"
       },
       "when": {
-        "facing": "east"
+        "facing": "up"
       }
     },
     {
       "apply": {
-        "model": "theurgy:block/caloric_flux_emitter"
+        "model": "theurgy:block/caloric_flux_emitter",
+        "x": 90
       },
       "when": {
         "facing": "north"
@@ -29,6 +29,7 @@
     {
       "apply": {
         "model": "theurgy:block/caloric_flux_emitter",
+        "x": 90,
         "y": 180
       },
       "when": {
@@ -38,19 +39,21 @@
     {
       "apply": {
         "model": "theurgy:block/caloric_flux_emitter",
-        "x": 270
+        "x": 90,
+        "y": 270
       },
       "when": {
-        "facing": "up"
+        "facing": "west"
       }
     },
     {
       "apply": {
         "model": "theurgy:block/caloric_flux_emitter",
-        "y": 270
+        "x": 90,
+        "y": 90
       },
       "when": {
-        "facing": "west"
+        "facing": "east"
       }
     }
   ]

--- a/src/generated/resources/assets/theurgy/blockstates/sulfuric_flux_emitter.json
+++ b/src/generated/resources/assets/theurgy/blockstates/sulfuric_flux_emitter.json
@@ -3,7 +3,7 @@
     {
       "apply": {
         "model": "theurgy:block/sulfuric_flux_emitter",
-        "x": 90
+        "x": 180
       },
       "when": {
         "facing": "down"
@@ -11,16 +11,16 @@
     },
     {
       "apply": {
-        "model": "theurgy:block/sulfuric_flux_emitter",
-        "y": 90
+        "model": "theurgy:block/sulfuric_flux_emitter"
       },
       "when": {
-        "facing": "east"
+        "facing": "up"
       }
     },
     {
       "apply": {
-        "model": "theurgy:block/sulfuric_flux_emitter"
+        "model": "theurgy:block/sulfuric_flux_emitter",
+        "x": 90
       },
       "when": {
         "facing": "north"
@@ -29,6 +29,7 @@
     {
       "apply": {
         "model": "theurgy:block/sulfuric_flux_emitter",
+        "x": 90,
         "y": 180
       },
       "when": {
@@ -38,19 +39,21 @@
     {
       "apply": {
         "model": "theurgy:block/sulfuric_flux_emitter",
-        "x": 270
+        "x": 90,
+        "y": 270
       },
       "when": {
-        "facing": "up"
+        "facing": "west"
       }
     },
     {
       "apply": {
         "model": "theurgy:block/sulfuric_flux_emitter",
-        "y": 270
+        "x": 90,
+        "y": 90
       },
       "when": {
-        "facing": "west"
+        "facing": "east"
       }
     }
   ]

--- a/src/main/java/com/klikli_dev/theurgy/datagen/model/TheurgyBlockModelSubProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/model/TheurgyBlockModelSubProvider.java
@@ -249,12 +249,10 @@ public class TheurgyBlockModelSubProvider {
         ));
 
         MultiPartGenerator generator = MultiPartGenerator.multiPart(block);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.DOWN, this.blockModel(block), 90, 0, false);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.EAST, this.blockModel(block), 0, 90, false);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.NORTH, this.blockModel(block), 0, 0, false);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.SOUTH, this.blockModel(block), 0, 180, false);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.UP, this.blockModel(block), 270, 0, false);
-        generator = this.addFacingVariant(generator, BlockStateProperties.FACING, Direction.WEST, this.blockModel(block), 0, 270, false);
+        for (Direction direction : Direction.values()) {
+            Rotation rotation = this.connectorRotation(direction);
+            generator = this.addFacingVariant(generator, BlockStateProperties.FACING, direction, this.blockModel(block), rotation.xDegrees, rotation.yDegrees, false);
+        }
         blockModels.blockStateOutput.accept(generator);
 
         this.registerParentedItemModel(itemModels, block, this.blockModel(block));


### PR DESCRIPTION
## Summary
- reuse the shared connector rotation mapping for flux emitter blockstate datagen
- regenerate caloric and sulfuric flux emitter blockstates with the corrected side-facing rotations
- fixes #324