### PR TITLE
fix: smooth calcination oven and distiller animation transitions

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationAnimationBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationAnimationBehaviour.java
@@ -30,15 +30,16 @@ public class CalcinationAnimationBehaviour extends AnimationBehaviour<Calcinatio
     @Override
     public PlayState animationHandler(AnimationTest<CalcinationOvenBlockEntity> event) {
         var isProcessing = this.blockEntity.craftingBehaviour.isProcessing();
+        var controller = event.controller();
 
-        if (this.wasProcessingLastTick && !isProcessing) {
-            event.setAnimation(STOP_AND_OFF_ANIM);
-        } else if (!this.wasProcessingLastTick && isProcessing) {
-            event.setAnimation(START_AND_ON_ANIM);
-        } else if (isProcessing) {
-            event.setAnimation(ON_ANIM);
-        } else {
-            event.setAnimation(OFF_ANIM);
+        if (this.wasProcessingLastTick && !isProcessing && !controller.isTransitioning()) {
+            controller.setAnimation(STOP_AND_OFF_ANIM);
+        } else if (!this.wasProcessingLastTick && isProcessing && !controller.isTransitioning()) {
+            controller.setAnimation(START_AND_ON_ANIM);
+        } else if (!this.wasProcessingLastTick && !isProcessing && !controller.isAnimatingBones()) {
+            controller.setAnimation(OFF_ANIM);
+        } else if (this.wasProcessingLastTick && isProcessing && !controller.isAnimatingBones()) {
+            controller.setAnimation(ON_ANIM);
         }
 
         this.wasProcessingLastTick = isProcessing;

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationAnimationBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationAnimationBehaviour.java
@@ -23,10 +23,6 @@ public class CalcinationAnimationBehaviour extends AnimationBehaviour<Calcinatio
     private static final RawAnimation ON_ANIM = RawAnimation.begin()
             .thenLoop("animation.calcination_oven.on");
 
-    private static final RawAnimation PLACE_AND_OFF_ANIM = RawAnimation.begin()
-            .thenPlay("animation.calcination_oven.place")
-            .thenLoop("animation.calcination_oven.off");
-
     public CalcinationAnimationBehaviour(CalcinationOvenBlockEntity blockEntity) {
         super(blockEntity);
     }
@@ -41,8 +37,6 @@ public class CalcinationAnimationBehaviour extends AnimationBehaviour<Calcinatio
             event.setAnimation(START_AND_ON_ANIM);
         } else if (isProcessing) {
             event.setAnimation(ON_ANIM);
-        } else if (!event.isCurrentAnimation(PLACE_AND_OFF_ANIM)) {
-            event.setAnimation(PLACE_AND_OFF_ANIM);
         } else {
             event.setAnimation(OFF_ANIM);
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlockEntity.java
@@ -133,7 +133,7 @@ public class CalcinationOvenBlockEntity extends BlockEntity implements GeoBlockE
 
     @Override
     public void registerControllers(AnimatableManager.ControllerRegistrar controllerRegistrar) {
-        controllerRegistrar.add(new AnimationController<CalcinationOvenBlockEntity>("controller", 10, this.animationBehaviour::animationHandler));
+        controllerRegistrar.add(new AnimationController<CalcinationOvenBlockEntity>("controller", 0, this.animationBehaviour::animationHandler));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
@@ -29,25 +29,22 @@ public class DistillerAnimationBehaviour extends AnimationBehaviour<DistillerBlo
     @Override
     public PlayState animationHandler(AnimationTest<DistillerBlockEntity> event) {
         var isProcessing = this.blockEntity.craftingBehaviour.isProcessing();
+        var controller = event.controller();
 
-        if (isProcessing && event.isCurrentAnimation(START_AND_ON_ANIM)) {
-            this.wasProcessingLastTick = true;
-            return PlayState.CONTINUE;
+        if (this.wasProcessingLastTick && !isProcessing && !controller.isTransitioning()) {
+            controller.setAnimation(STOP_AND_OFF_ANIM);
         }
 
-        if (!isProcessing && event.isCurrentAnimation(STOP_AND_OFF_ANIM)) {
-            this.wasProcessingLastTick = false;
-            return PlayState.CONTINUE;
+        if (!this.wasProcessingLastTick && isProcessing && !controller.isTransitioning()) {
+            controller.setAnimation(START_AND_ON_ANIM);
         }
 
-        if (this.wasProcessingLastTick && !isProcessing) {
-            event.setAnimation(STOP_AND_OFF_ANIM);
-        } else if (!this.wasProcessingLastTick && isProcessing) {
-            event.setAnimation(START_AND_ON_ANIM);
-        } else if (isProcessing) {
-            event.setAnimation(ON_ANIM);
-        } else {
-            event.setAnimation(OFF_ANIM);
+        if (!this.wasProcessingLastTick && !isProcessing && !controller.isAnimatingBones()) {
+            controller.setAnimation(OFF_ANIM);
+        }
+
+        if (this.wasProcessingLastTick && isProcessing && !controller.isAnimatingBones()) {
+            controller.setAnimation(ON_ANIM);
         }
 
         this.wasProcessingLastTick = isProcessing;

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
@@ -30,6 +30,16 @@ public class DistillerAnimationBehaviour extends AnimationBehaviour<DistillerBlo
     public PlayState animationHandler(AnimationTest<DistillerBlockEntity> event) {
         var isProcessing = this.blockEntity.craftingBehaviour.isProcessing();
 
+        if (isProcessing && event.isCurrentAnimation(START_AND_ON_ANIM)) {
+            this.wasProcessingLastTick = true;
+            return PlayState.CONTINUE;
+        }
+
+        if (!isProcessing && event.isCurrentAnimation(STOP_AND_OFF_ANIM)) {
+            this.wasProcessingLastTick = false;
+            return PlayState.CONTINUE;
+        }
+
         if (this.wasProcessingLastTick && !isProcessing) {
             event.setAnimation(STOP_AND_OFF_ANIM);
         } else if (!this.wasProcessingLastTick && isProcessing) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerAnimationBehaviour.java
@@ -33,17 +33,11 @@ public class DistillerAnimationBehaviour extends AnimationBehaviour<DistillerBlo
 
         if (this.wasProcessingLastTick && !isProcessing && !controller.isTransitioning()) {
             controller.setAnimation(STOP_AND_OFF_ANIM);
-        }
-
-        if (!this.wasProcessingLastTick && isProcessing && !controller.isTransitioning()) {
+        } else if (!this.wasProcessingLastTick && isProcessing && !controller.isTransitioning()) {
             controller.setAnimation(START_AND_ON_ANIM);
-        }
-
-        if (!this.wasProcessingLastTick && !isProcessing && !controller.isAnimatingBones()) {
+        } else if (!this.wasProcessingLastTick && !isProcessing && !controller.isAnimatingBones()) {
             controller.setAnimation(OFF_ANIM);
-        }
-
-        if (this.wasProcessingLastTick && isProcessing && !controller.isAnimatingBones()) {
+        } else if (this.wasProcessingLastTick && isProcessing && !controller.isAnimatingBones()) {
             controller.setAnimation(ON_ANIM);
         }
 


### PR DESCRIPTION
## Summary
- fix calcination oven idle and processing transition handling so it no longer oscillates or briefly plays the placement unfold animation
- restore smooth start and stop transitions for the mercury distiller by mirroring the guarded animation control approach from 1.21.1 in GeckoLib 5.5
- adjust the calcination oven controller timing so placement goes straight into the intended off state

Closes #323