### PR TITLE
feat: show crafting progress in all in-world block huds

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -5,11 +5,10 @@
 package com.klikli_dev.theurgy.content.render.inworldhud;
 
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.BlockTitleInWorldHUDProvider;
-import com.klikli_dev.theurgy.content.render.inworldhud.provider.CalcinationOvenCraftingProgressInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.FluidStorageInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.GenericCraftingProgressInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.ItemStorageInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxStorageInWorldHUDProvider;
-import com.klikli_dev.theurgy.registry.BlockRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -36,10 +35,10 @@ public class InWorldHUDRegistry {
         }
 
         registerGenericProvider(new BlockTitleInWorldHUDProvider());
+        registerGenericProvider(new GenericCraftingProgressInWorldHUDProvider());
         registerGenericProvider(new MercuryFluxStorageInWorldHUDProvider());
         registerGenericProvider(new FluidStorageInWorldHUDProvider());
         registerGenericProvider(new ItemStorageInWorldHUDProvider());
-        registerBlockProvider(BlockRegistry.CALCINATION_OVEN.get(), new CalcinationOvenCraftingProgressInWorldHUDProvider());
 
         defaultsRegistered = true;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/GenericCraftingProgressInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/GenericCraftingProgressInWorldHUDProvider.java
@@ -5,8 +5,7 @@
 package com.klikli_dev.theurgy.content.render.inworldhud.provider;
 
 import com.klikli_dev.theurgy.TheurgyConstants;
-import com.klikli_dev.theurgy.content.apparatus.calcinationoven.CalcinationOvenBlock;
-import com.klikli_dev.theurgy.content.apparatus.calcinationoven.CalcinationOvenBlockEntity;
+import com.klikli_dev.theurgy.content.behaviour.crafting.HasCraftingBehaviour;
 import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDBuilder;
 import com.klikli_dev.theurgy.content.render.inworldhud.InWorldHUDProvider;
 import net.minecraft.ChatFormatting;
@@ -17,10 +16,11 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import org.jetbrains.annotations.Nullable;
 
-public class CalcinationOvenCraftingProgressInWorldHUDProvider implements InWorldHUDProvider {
+public class GenericCraftingProgressInWorldHUDProvider implements InWorldHUDProvider {
 
     private static final int BAR_WIDTH = 10;
     private static final String FILLED_SEGMENT = "█";
@@ -33,17 +33,17 @@ public class CalcinationOvenCraftingProgressInWorldHUDProvider implements InWorl
 
     @Override
     public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
-        return state.getBlock() instanceof CalcinationOvenBlock;
+        return this.getCraftingBlockEntity(level, pos, state, blockEntity) != null;
     }
 
     @Override
     public void appendServerData(InWorldHUDBuilder builder, ServerPlayer player, ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
-        CalcinationOvenBlockEntity oven = this.getBlockEntity(level, pos, state, blockEntity);
-        if (oven == null || !oven.craftingBehaviour().isProcessing()) {
+        HasCraftingBehaviour<?, ?, ?> craftingBlockEntity = this.getCraftingBlockEntity(level, pos, state, blockEntity);
+        if (craftingBlockEntity == null || !craftingBlockEntity.craftingBehaviour().isProcessing()) {
             return;
         }
 
-        int progressPercent = oven.craftingBehaviour().progressPercent();
+        int progressPercent = craftingBlockEntity.craftingBehaviour().progressPercent();
 
         builder.addLine(Component.translatable(
                 TheurgyConstants.I18n.Misc.CRAFTING_PROGRESS,
@@ -57,15 +57,15 @@ public class CalcinationOvenCraftingProgressInWorldHUDProvider implements InWorl
         return FILLED_SEGMENT.repeat(filledSegments) + EMPTY_SEGMENT.repeat(BAR_WIDTH - filledSegments);
     }
 
-    private @Nullable CalcinationOvenBlockEntity getBlockEntity(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
-        if (blockEntity instanceof CalcinationOvenBlockEntity oven) {
-            return oven;
+    private @Nullable HasCraftingBehaviour<?, ?, ?> getCraftingBlockEntity(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
+        if (blockEntity instanceof HasCraftingBehaviour<?, ?, ?> craftingBlockEntity) {
+            return craftingBlockEntity;
         }
 
-        if (state.hasProperty(CalcinationOvenBlock.HALF) && state.getValue(CalcinationOvenBlock.HALF) == DoubleBlockHalf.UPPER) {
+        if (state.hasProperty(BlockStateProperties.DOUBLE_BLOCK_HALF) && state.getValue(BlockStateProperties.DOUBLE_BLOCK_HALF) == DoubleBlockHalf.UPPER) {
             BlockEntity lowerBlockEntity = level.getBlockEntity(pos.below());
-            if (lowerBlockEntity instanceof CalcinationOvenBlockEntity oven) {
-                return oven;
+            if (lowerBlockEntity instanceof HasCraftingBehaviour<?, ?, ?> craftingBlockEntity) {
+                return craftingBlockEntity;
             }
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/GenericCraftingProgressInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/GenericCraftingProgressInWorldHUDProvider.java
@@ -33,7 +33,8 @@ public class GenericCraftingProgressInWorldHUDProvider implements InWorldHUDProv
 
     @Override
     public boolean applies(Level level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity) {
-        return this.getCraftingBlockEntity(level, pos, state, blockEntity) != null;
+        HasCraftingBehaviour<?, ?, ?> craftingBlockEntity = this.getCraftingBlockEntity(level, pos, state, blockEntity);
+        return craftingBlockEntity != null && craftingBlockEntity.craftingBehaviour().isProcessing();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- generalize the in-world HUD crafting progress provider to work for any block entity with `HasCraftingBehaviour`
- keep double-height apparatus support by resolving upper-half lookups to the lower block entity
- replace the calcination-oven-specific registration with the shared provider

## Validation
- `./gradlew.bat compileJava`