### PR TITLE
fix(jei): remove deprecated ingredient builder calls

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/JeiIngredients.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/JeiIngredients.java
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.integration.jei;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.context.ContextMap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.display.SlotDisplayContext;
+import net.neoforged.neoforge.common.crafting.SizedIngredient;
+
+import java.util.List;
+
+public final class JeiIngredients {
+    private JeiIngredients() {
+    }
+
+    /**
+     * Resolve vanilla ingredient displays through the client recipe-display context so JEI can
+     * render non-deprecated stack variants without relying on Ingredient.items().
+     */
+    public static List<ItemStack> getStacks(Ingredient ingredient) {
+        return ingredient.display().resolveForStacks(context());
+    }
+
+    public static List<ItemStack> getStacks(Ingredient ingredient, int count) {
+        return getStacks(ingredient).stream().map(stack -> stack.copyWithCount(count)).toList();
+    }
+
+    public static List<ItemStack> getStacks(SizedIngredient ingredient) {
+        return getStacks(ingredient.ingredient(), ingredient.count());
+    }
+
+    private static ContextMap context() {
+        var level = Minecraft.getInstance().level;
+        return level != null ? SlotDisplayContext.fromLevel(level) : ContextMap.EMPTY;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/AccumulationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/AccumulationCategory.java
@@ -137,15 +137,15 @@ public class AccumulationCategory implements IRecipeCategory<RecipeHolder<Accumu
             assert recipe.value().solute() != null;
             builder.addSlot(INPUT, 1, 21)
                     .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                    .addIngredients(recipe.value().solute());
+                    .add(recipe.value().solute());
         }
 
         builder.addSlot(OUTPUT, 56, 1)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addFluidStack(recipe.value().result().fluid().value(), recipe.value().result().amount());
+                .add(recipe.value().result().fluid().value(), recipe.value().result().amount());
 
         //now add the bucket to the recipe lookup for the output fluid
-        builder.addInvisibleIngredients(OUTPUT).addItemStack(new ItemStack(recipe.value().result().fluid().value().getBucket()));
+        builder.addInvisibleIngredients(OUTPUT).add(new ItemStack(recipe.value().result().fluid().value().getBucket()));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/CalcinationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/CalcinationCategory.java
@@ -11,9 +11,9 @@ import com.klikli_dev.theurgy.TheurgyConstants;
 import com.klikli_dev.theurgy.content.gui.GuiTextures;
 import com.klikli_dev.theurgy.content.recipe.CalcinationRecipe;
 import com.klikli_dev.theurgy.integration.jei.JeiDrawables;
+import com.klikli_dev.theurgy.integration.jei.JeiIngredients;
 import com.klikli_dev.theurgy.integration.jei.JeiRecipeTypes;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -119,11 +119,11 @@ public class CalcinationCategory implements IRecipeCategory<RecipeHolder<Calcina
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CalcinationRecipe> recipe, @NotNull IFocusGroup focuses) {
         builder.addSlot(INPUT, 1, 1)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(VanillaTypes.ITEM_STACK, recipe.value().getIngredients().getFirst().items().map(h -> new ItemStack(h.value())).map(i -> i.copyWithCount(recipe.value().getIngredientCount())).toList());
+                .addItemStacks(JeiIngredients.getStacks(recipe.value().getIngredients().getFirst(), recipe.value().getIngredientCount()));
 
         builder.addSlot(OUTPUT, 61, 9)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/DigestionCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/DigestionCategory.java
@@ -11,9 +11,9 @@ import com.klikli_dev.theurgy.TheurgyConstants;
 import com.klikli_dev.theurgy.content.gui.GuiTextures;
 import com.klikli_dev.theurgy.content.recipe.DigestionRecipe;
 import com.klikli_dev.theurgy.integration.jei.JeiDrawables;
+import com.klikli_dev.theurgy.integration.jei.JeiIngredients;
 import com.klikli_dev.theurgy.integration.jei.JeiRecipeTypes;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -134,7 +134,7 @@ public class DigestionCategory implements IRecipeCategory<RecipeHolder<Digestion
 
         var ingredient = ingredients.get(ingredientIndex);
 
-        builder.addIngredients(VanillaTypes.ITEM_STACK, ingredient.ingredient().items().map(h -> new ItemStack(h.value())).map(i -> i.copyWithCount(ingredient.count())).toList());
+        builder.addItemStacks(JeiIngredients.getStacks(ingredient));
     }
 
     @Override
@@ -153,7 +153,7 @@ public class DigestionCategory implements IRecipeCategory<RecipeHolder<Digestion
 
         builder.addSlot(OUTPUT, 81, 9)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
 
         builder.addSlot(INPUT, 1 + 18, 1 + 18)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/DistillationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/DistillationCategory.java
@@ -11,9 +11,9 @@ import com.klikli_dev.theurgy.TheurgyConstants;
 import com.klikli_dev.theurgy.content.gui.GuiTextures;
 import com.klikli_dev.theurgy.content.recipe.DistillationRecipe;
 import com.klikli_dev.theurgy.integration.jei.JeiDrawables;
+import com.klikli_dev.theurgy.integration.jei.JeiIngredients;
 import com.klikli_dev.theurgy.integration.jei.JeiRecipeTypes;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -119,11 +119,11 @@ public class DistillationCategory implements IRecipeCategory<RecipeHolder<Distil
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<DistillationRecipe> recipe, @NotNull IFocusGroup focuses) {
         builder.addSlot(INPUT, 1, 1)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(VanillaTypes.ITEM_STACK, recipe.value().getIngredient().ingredient().items().map(h -> new ItemStack(h.value())).map(i -> i.copyWithCount(recipe.value().getIngredientCount())).toList());
+                .addItemStacks(JeiIngredients.getStacks(recipe.value().getIngredient().ingredient(), recipe.value().getIngredientCount()));
 
         builder.addSlot(OUTPUT, 61, 9)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/FermentationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/FermentationCategory.java
@@ -136,17 +136,17 @@ public class FermentationCategory implements IRecipeCategory<RecipeHolder<Fermen
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1);
 
         if (!recipe.value().getIngredients().isEmpty())
-            topLeft.addIngredients(recipe.value().getIngredients().get(0));
+            topLeft.add(recipe.value().getIngredients().get(0));
 
         if (recipe.value().getIngredients().size() > 1)
-            topRight.addIngredients(recipe.value().getIngredients().get(1));
+            topRight.add(recipe.value().getIngredients().get(1));
 
         if (recipe.value().getIngredients().size() > 2)
-            bottomLeft.addIngredients(recipe.value().getIngredients().get(2));
+            bottomLeft.add(recipe.value().getIngredients().get(2));
 
         builder.addSlot(OUTPUT, 81, 9)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
 
         builder.addSlot(INPUT, 1 + 18, 1 + 18)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/IncubationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/IncubationCategory.java
@@ -11,6 +11,7 @@ import com.klikli_dev.theurgy.TheurgyConstants;
 import com.klikli_dev.theurgy.content.gui.GuiTextures;
 import com.klikli_dev.theurgy.content.recipe.IncubationRecipe;
 import com.klikli_dev.theurgy.integration.jei.JeiDrawables;
+import com.klikli_dev.theurgy.integration.jei.JeiIngredients;
 import com.klikli_dev.theurgy.integration.jei.JeiRecipeTypes;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
@@ -119,15 +120,15 @@ public class IncubationCategory implements IRecipeCategory<RecipeHolder<Incubati
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<IncubationRecipe> recipe, @NotNull IFocusGroup focuses) {
         builder.addSlot(INPUT, 1, 1)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(recipe.value().mercury());
+                .add(recipe.value().mercury());
 
         builder.addSlot(INPUT, 1, 21)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addItemStacks(recipe.value().sulfur().items().map(h -> new ItemStack(h.value())).toList());
+                .addItemStacks(JeiIngredients.getStacks(recipe.value().sulfur()));
 
         builder.addSlot(INPUT, 1, 42)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(recipe.value().salt());
+                .add(recipe.value().salt());
 
         builder.addSlot(OUTPUT, 61, 22)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/LiquefactionCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/LiquefactionCategory.java
@@ -141,10 +141,10 @@ public class LiquefactionCategory implements IRecipeCategory<RecipeHolder<Liquef
 
         builder.addSlot(INPUT, 19, 1)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(recipe.value().getIngredients().getFirst());
+                .add(recipe.value().getIngredients().getFirst());
         builder.addSlot(OUTPUT, 81, 9)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
 
         //now add the bucket to the recipe lookup for the output fluid
         builder.addInvisibleIngredients(INPUT).addItemStacks(recipe.value().getSolvent().ingredient().fluids().stream().map(f -> new ItemStack(f.value().getBucket())).toList());

--- a/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/ReformationCategory.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jei/recipes/ReformationCategory.java
@@ -11,12 +11,12 @@ import com.klikli_dev.theurgy.TheurgyConstants;
 import com.klikli_dev.theurgy.content.gui.GuiTextures;
 import com.klikli_dev.theurgy.content.recipe.ReformationRecipe;
 import com.klikli_dev.theurgy.integration.jei.JeiDrawables;
+import com.klikli_dev.theurgy.integration.jei.JeiIngredients;
 import com.klikli_dev.theurgy.integration.jei.JeiRecipeTypes;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
 import com.klikli_dev.theurgy.registry.ItemRegistry;
 import com.mojang.blaze3d.systems.RenderSystem;
 import mezz.jei.api.recipe.RecipeIngredientRole;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -34,12 +34,9 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.neoforged.neoforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static mezz.jei.api.recipe.RecipeIngredientRole.INPUT;
@@ -154,15 +151,15 @@ public class ReformationCategory implements IRecipeCategory<RecipeHolder<Reforma
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ReformationRecipe> recipe, @NotNull IFocusGroup focuses) {
         builder.addSlot(INPUT, 1, 15)
-                .addItemStack(new ItemStack(ItemRegistry.SULFURIC_FLUX_EMITTER.get()));
+                .add(new ItemStack(ItemRegistry.SULFURIC_FLUX_EMITTER.get()));
 
 
         builder.addSlot(INPUT, 45, 19)
                 .setBackground(JeiDrawables.INPUT_SLOT, -1, -1)
-                .addIngredients(recipe.value().getTarget());
+                .add(recipe.value().getTarget());
 
         builder.addSlot(INPUT, 45, 35)
-                .addItemStack(new ItemStack(ItemRegistry.REFORMATION_TARGET_PEDESTAL.get()));
+                .add(new ItemStack(ItemRegistry.REFORMATION_TARGET_PEDESTAL.get()));
 
         //8 source slots, 2 columns, 4 rows
         int sourceSlotX = 90;
@@ -174,7 +171,7 @@ public class ReformationCategory implements IRecipeCategory<RecipeHolder<Reforma
 
             if (i < recipe.value().getSources().size()) {
                 var ingredient = recipe.value().getSources().get(i);
-                slot.addIngredients(VanillaTypes.ITEM_STACK, ingredient.ingredient().items().map(h -> new ItemStack(h.value())).map(stack -> stack.copyWithCount(ingredient.count())).toList());
+                slot.addItemStacks(JeiIngredients.getStacks(ingredient));
             }
 
             sourceSlotY -= 18; // Move upwards
@@ -185,14 +182,14 @@ public class ReformationCategory implements IRecipeCategory<RecipeHolder<Reforma
         }
 
         builder.addSlot(INPUT, 90 + 9, startY + 18)
-                .addItemStack(new ItemStack(ItemRegistry.REFORMATION_SOURCE_PEDESTAL.get()));
+                .add(new ItemStack(ItemRegistry.REFORMATION_SOURCE_PEDESTAL.get()));
 
 
         builder.addSlot(OUTPUT, 160, 19)
                 .setBackground(JeiDrawables.OUTPUT_SLOT, -5, -5)
-                .addItemStack(recipe.value().getResultItem(RegistryAccess.EMPTY));
+                .add(recipe.value().getResultItem(RegistryAccess.EMPTY));
         builder.addSlot(INPUT, 160, 42)
-                .addItemStack(new ItemStack(ItemRegistry.REFORMATION_RESULT_PEDESTAL.get()));
+                .add(new ItemStack(ItemRegistry.REFORMATION_RESULT_PEDESTAL.get()));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- replace deprecated JEI slot builder convenience calls in the JEI integration recipe categories
- resolve vanilla ingredient displays through a shared helper instead of deprecated Ingredient.items() access
- verify the JEI package is free of deprecation warnings with compileJava

## Testing
- ./gradlew.bat compileJava
- ./gradlew.bat compileJava --rerun-tasks --init-script " gradle/compile-deprecations.init.gradle\