### PR TITLE
fix: backfill logistics inserter targets regardless of link order

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/logistics/InserterNodeBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/logistics/InserterNodeBehaviour.java
@@ -114,7 +114,7 @@ public abstract class InserterNodeBehaviour<T, C> extends LeafNodeBehaviour<T, C
             if (!forceSetRemoved) {
                 this.targetCapabilities.stream()
                         .filter(cache -> cache.pos().equals(targetPos))
-                        .filter(cache -> cache.getCapability() != null)
+                        .filter(this::hasAvailableTargetCapability)
                         .forEach(cache -> network.onInserterNodeTargetAdded(targetGlobalPos, cache, this));
             }
         }
@@ -126,7 +126,7 @@ public abstract class InserterNodeBehaviour<T, C> extends LeafNodeBehaviour<T, C
      */
     protected void notifyTargetCapabilityCacheCreated(BlockCapabilityCache<T, C> capability) {
         //only notify if we actually have a valid one - otherwise onCapabilityInvalidated will handle it on load of target
-        var targetValid = capability.getCapability() != null;
+        var targetValid = this.hasAvailableTargetCapability(capability);
 
         var targetGlobalPos = GlobalPos.of(this.level().dimension(), capability.pos());
 
@@ -142,7 +142,15 @@ public abstract class InserterNodeBehaviour<T, C> extends LeafNodeBehaviour<T, C
      * @return
      */
     public List<BlockCapabilityCache<T, C>> availableTargetCapabilities() {
-        return this.targetCapabilities.stream().filter(cache -> cache.getCapability() != null).toList();
+        return this.targetCapabilities.stream().filter(this::hasAvailableTargetCapability).toList();
+    }
+
+    protected boolean hasAvailableTargetCapability(BlockCapabilityCache<T, C> capability) {
+        if (capability.getCapability() != null) {
+            return true;
+        }
+
+        return this.level().getCapability(this.capabilityType(), capability.pos(), capability.context()) != null;
     }
 
     /**

--- a/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
@@ -417,6 +417,12 @@ public class GameTestRegistry {
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LOG_FLUID_EXTRACTS_WORLD_SOURCE =
             TEST_FUNCTIONS.register("logistics_fluid_extracts_world_source", () -> LogisticsGameTests::fluidExtractorPullsFromWorldSource);
 
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LOG_ITEM_EXTRACTOR_TARGETS_IN_ANY_REGISTRATION_ORDER =
+            TEST_FUNCTIONS.register("logistics_item_extractor_targets_in_any_registration_order", () -> LogisticsGameTests::itemExtractorFindsInserterTargetRegardlessOfRegistrationOrder);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LOG_ITEM_EXTRACTOR_TARGETS_IN_ANY_REGISTRATION_ORDER_REVERSED =
+            TEST_FUNCTIONS.register("logistics_item_extractor_targets_in_any_registration_order_reversed", () -> LogisticsGameTests::itemExtractorFindsInserterTargetRegardlessOfRegistrationOrderReversed);
+
     // --- Logistics Capability Proxy ---
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> LCP_PLACEMENT =
@@ -662,6 +668,8 @@ private static void registerSulfuricFluxEmitterTests(RegisterGameTestsEvent even
         registerTest(event, LOG_INSERTER_PLACEMENT, environment, structure, 40, 0);
         registerTest(event, LOG_EXTRACTOR_PLACEMENT, environment, structure, 40, 0);
         registerTest(event, LOG_FLUID_EXTRACTS_WORLD_SOURCE, environment, structure, 80, 0);
+        registerTest(event, LOG_ITEM_EXTRACTOR_TARGETS_IN_ANY_REGISTRATION_ORDER, environment, structure, 40, 0);
+        registerTest(event, LOG_ITEM_EXTRACTOR_TARGETS_IN_ANY_REGISTRATION_ORDER_REVERSED, environment, structure, 40, 0);
         registerTest(event, LCP_PLACEMENT, environment, structure, 40, 0);
         registerTest(event, LCP_FLUID_FORWARDING, environment, structure, 100, 0);
         registerTest(event, LCP_FLUID_ROUND_ROBIN, environment, structure, 100, 0);

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LogisticsGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LogisticsGameTests.java
@@ -6,6 +6,8 @@ package com.klikli_dev.theurgy.gametest;
 
 import com.klikli_dev.theurgy.content.apparatus.logisticsfluidconnector.extractor.LogisticsFluidExtractorBlockEntity;
 import com.klikli_dev.theurgy.content.apparatus.logisticsfluidconnector.inserter.LogisticsFluidInserterBlockEntity;
+import com.klikli_dev.theurgy.content.apparatus.logisticsitemconnector.extractor.LogisticsItemExtractorBlockEntity;
+import com.klikli_dev.theurgy.content.apparatus.logisticsitemconnector.inserter.LogisticsItemInserterBlockEntity;
 import com.klikli_dev.theurgy.content.apparatus.salammoniactank.SalAmmoniacTankBlockEntity;
 import com.klikli_dev.theurgy.logistics.Logistics;
 import com.klikli_dev.theurgy.registry.BlockRegistry;
@@ -18,9 +20,9 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.item.ItemStack;
 
 public class LogisticsGameTests {
 
@@ -31,6 +33,10 @@ public class LogisticsGameTests {
     private static final BlockPos FLUID_EXTRACTOR_POS = new BlockPos(2, 2, 2);
     private static final BlockPos FLUID_INSERTER_POS = new BlockPos(4, 2, 2);
     private static final BlockPos FLUID_TANK_POS = new BlockPos(5, 2, 2);
+    private static final BlockPos ITEM_INSERTER_TARGET_POS = new BlockPos(2, 2, 2);
+    private static final BlockPos ITEM_INSERTER_POS = new BlockPos(3, 2, 2);
+    private static final BlockPos ITEM_EXTRACTOR_POS = new BlockPos(5, 2, 2);
+    private static final BlockPos ITEM_EXTRACTOR_TARGET_POS = new BlockPos(6, 2, 2);
 
     // --- Connection Node ---
 
@@ -63,6 +69,14 @@ public class LogisticsGameTests {
         helper.assertBlockPresent(BlockRegistry.LOGISTICS_ITEM_EXTRACTOR.get(), EXTRACTOR_POS);
         helper.assertBlockProperty(EXTRACTOR_POS, BlockStateProperties.FACING, Direction.NORTH);
         helper.succeed();
+    }
+
+    public static void itemExtractorFindsInserterTargetRegardlessOfRegistrationOrder(GameTestHelper helper) {
+        assertItemExtractorFindsInserterTarget(helper, true);
+    }
+
+    public static void itemExtractorFindsInserterTargetRegardlessOfRegistrationOrderReversed(GameTestHelper helper) {
+        assertItemExtractorFindsInserterTarget(helper, false);
     }
 
     public static void fluidExtractorPullsFromWorldSource(GameTestHelper helper) {
@@ -123,6 +137,54 @@ public class LogisticsGameTests {
             helper.assertTrue(tank.tank.getFluid().getFluid() == Blocks.WATER.defaultBlockState().getFluidState().getType(), "Tank should contain water");
             helper.assertTrue(level.getBlockState(sourcePos).is(Blocks.WATER), "Water source block should remain after extraction");
             helper.assertTrue(level.getFluidState(sourcePos).isSource(), "Water source should remain a source after extraction");
+        });
+    }
+
+    private static void assertItemExtractorFindsInserterTarget(GameTestHelper helper, boolean extractorFirst) {
+        helper.setBlock(ITEM_INSERTER_TARGET_POS, Blocks.CHEST);
+        helper.setBlock(ITEM_INSERTER_POS, BlockRegistry.LOGISTICS_ITEM_INSERTER.get().defaultBlockState().setValue(BlockStateProperties.FACING, Direction.EAST));
+        helper.setBlock(ITEM_EXTRACTOR_POS, BlockRegistry.LOGISTICS_ITEM_EXTRACTOR.get().defaultBlockState().setValue(BlockStateProperties.FACING, Direction.WEST));
+        helper.setBlock(ITEM_EXTRACTOR_TARGET_POS, Blocks.CHEST);
+
+        helper.runAfterDelay(1, () -> {
+            var level = helper.getLevel();
+            var inserterPos = helper.absolutePos(ITEM_INSERTER_POS);
+            var inserterTargetPos = helper.absolutePos(ITEM_INSERTER_TARGET_POS);
+            var extractorPos = helper.absolutePos(ITEM_EXTRACTOR_POS);
+            var extractorTargetPos = helper.absolutePos(ITEM_EXTRACTOR_TARGET_POS);
+
+            var inserter = helper.getBlockEntity(ITEM_INSERTER_POS, LogisticsItemInserterBlockEntity.class);
+            var extractor = helper.getBlockEntity(ITEM_EXTRACTOR_POS, LogisticsItemExtractorBlockEntity.class);
+
+            Logistics.get().remove(inserter.leafNode(), false);
+            Logistics.get().remove(extractor.leafNode(), false);
+
+            inserter.leafNode().targets().clear();
+            inserter.leafNode().targets().add(inserterTargetPos);
+            inserter.leafNode().directionOverride(Direction.EAST);
+
+            extractor.leafNode().targets().clear();
+            extractor.leafNode().targets().add(extractorTargetPos);
+            extractor.leafNode().directionOverride(Direction.WEST);
+
+            Logistics.get().add(GlobalPos.of(level.dimension(), inserterPos), GlobalPos.of(level.dimension(), extractorPos));
+
+            if (extractorFirst) {
+                Logistics.get().add(extractor.leafNode());
+                Logistics.get().add(inserter.leafNode());
+            } else {
+                Logistics.get().add(inserter.leafNode());
+                Logistics.get().add(extractor.leafNode());
+            }
+
+            helper.assertTrue(
+                    extractor.leafNode().insertTargets().stream().anyMatch(target ->
+                            target.inserter().globalPos().equals(GlobalPos.of(level.dimension(), inserterPos))
+                                    && target.capability().pos().equals(inserterTargetPos)),
+                    "Extractor should discover the inserter target regardless of registration order"
+            );
+
+            helper.succeed();
         });
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LogisticsGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LogisticsGameTests.java
@@ -146,12 +146,13 @@ public class LogisticsGameTests {
         helper.setBlock(ITEM_EXTRACTOR_POS, BlockRegistry.LOGISTICS_ITEM_EXTRACTOR.get().defaultBlockState().setValue(BlockStateProperties.FACING, Direction.WEST));
         helper.setBlock(ITEM_EXTRACTOR_TARGET_POS, Blocks.CHEST);
 
+        var inserterPos = helper.absolutePos(ITEM_INSERTER_POS);
+        var inserterTargetPos = helper.absolutePos(ITEM_INSERTER_TARGET_POS);
+        var extractorPos = helper.absolutePos(ITEM_EXTRACTOR_POS);
+        var extractorTargetPos = helper.absolutePos(ITEM_EXTRACTOR_TARGET_POS);
+
         helper.runAfterDelay(1, () -> {
             var level = helper.getLevel();
-            var inserterPos = helper.absolutePos(ITEM_INSERTER_POS);
-            var inserterTargetPos = helper.absolutePos(ITEM_INSERTER_TARGET_POS);
-            var extractorPos = helper.absolutePos(ITEM_EXTRACTOR_POS);
-            var extractorTargetPos = helper.absolutePos(ITEM_EXTRACTOR_TARGET_POS);
 
             var inserter = helper.getBlockEntity(ITEM_INSERTER_POS, LogisticsItemInserterBlockEntity.class);
             var extractor = helper.getBlockEntity(ITEM_EXTRACTOR_POS, LogisticsItemExtractorBlockEntity.class);
@@ -176,6 +177,11 @@ public class LogisticsGameTests {
                 Logistics.get().add(inserter.leafNode());
                 Logistics.get().add(extractor.leafNode());
             }
+        });
+
+        helper.succeedWhen(() -> {
+            var level = helper.getLevel();
+            var extractor = helper.getBlockEntity(ITEM_EXTRACTOR_POS, LogisticsItemExtractorBlockEntity.class);
 
             helper.assertTrue(
                     extractor.leafNode().insertTargets().stream().anyMatch(target ->
@@ -183,8 +189,6 @@ public class LogisticsGameTests {
                                     && target.capability().pos().equals(inserterTargetPos)),
                     "Extractor should discover the inserter target regardless of registration order"
             );
-
-            helper.succeed();
         });
     }
 }


### PR DESCRIPTION
## Summary
- fix inserter target discovery so extractors can backfill inserter targets regardless of connection order
- preserve capability cache re-arming while falling back to a live capability presence check during cold cache discovery
- add regression GameTests for both extractor-first and inserter-first registration orders