### PR TITLE
fix: forwardport logistics network cache crash to 26.1.2

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/logistics/Logistics.java
+++ b/src/main/java/com/klikli_dev/theurgy/logistics/Logistics.java
@@ -352,12 +352,7 @@ public class Logistics extends SavedData {
             network = netA;
         } else if (netA != netB) {
             //merge networks
-            if (netA.nodes().size() == 1) //in case netB is also 1 that is fine.
-                network = this.mergeSingle(netB, netA);
-            else if (netB.nodes().size() == 1)
-                network = this.mergeSingle(netA, netB);
-            else
-                network = this.merge(netA, netB);
+            network = this.merge(netA, netB);
         } else {
             //already in the same network .. so we just choose A
             network = netA;
@@ -471,16 +466,6 @@ public class Logistics extends SavedData {
     }
 
     /**
-     * Merges a network with only one node into a larger network.
-     * This means it will never perform a cache rebuild.
-     * Instead, in the case of a leaf being the added one it being added to the network will fire the necessary event.
-     */
-    private LogisticsNetwork mergeSingle(LogisticsNetwork network, LogisticsNetwork singleNodeNetwork) {
-        network.merge(singleNodeNetwork);
-        return network;
-    }
-
-    /**
      * Builds a logistics network from a root node and it's connected nodes.
      *
      * @param rootNode    the root node. This has no special meaning, it is just the first one we query.
@@ -492,18 +477,29 @@ public class Logistics extends SavedData {
         var network = new LogisticsNetwork();
 
         //add the root node
-        network.addNode(rootNode);
-        this.blockPosToNetwork.put(rootNode, network);
-        onNodeAdded.accept(rootNode);
+        this.addNodeToNetwork(network, rootNode, onNodeAdded);
 
         //now add all other nodes
         connected.forEach(c -> {
-            network.addNode(c);
-            this.blockPosToNetwork.put(c, network);
-            onNodeAdded.accept(c);
+            this.addNodeToNetwork(network, c, onNodeAdded);
         });
 
         return network;
+    }
+
+    private void addNodeToNetwork(LogisticsNetwork network, GlobalPos node, Consumer<GlobalPos> onNodeAdded) {
+        network.addNode(node);
+        this.blockPosToNetwork.put(node, network);
+        onNodeAdded.accept(node);
+
+        if (server() == null) {
+            return;
+        }
+
+        var leafNode = this.getLeafNode(node);
+        if (leafNode != null) {
+            network.trackLeafNode(leafNode);
+        }
     }
 
 }

--- a/src/main/java/com/klikli_dev/theurgy/logistics/LogisticsNetwork.java
+++ b/src/main/java/com/klikli_dev/theurgy/logistics/LogisticsNetwork.java
@@ -51,9 +51,7 @@ public class LogisticsNetwork {
     }
 
     public void addLeafNode(LeafNodeBehaviour<?, ?> leafNode) {
-        var pos = leafNode.globalPos();
-        this.leafNodes.add(pos);
-        this.keyToLeafNodes.put(new Key(leafNode.capabilityType(), leafNode.frequency()), pos);
+        this.trackLeafNode(leafNode);
 
         if (leafNode.mode() == LeafNodeMode.INSERT) {
             this.onLoadInsertNode(leafNode.asInserter());
@@ -64,9 +62,7 @@ public class LogisticsNetwork {
     }
 
     public void removeLeafNode(LeafNodeBehaviour<?, ?> leafNode) {
-        var pos = leafNode.globalPos();
-        this.leafNodes.remove(pos);
-        this.keyToLeafNodes.remove(new Key(leafNode.capabilityType(), leafNode.frequency()), pos);
+        this.untrackLeafNode(leafNode);
 
         if (leafNode.mode() == LeafNodeMode.INSERT) {
             this.onUnloadInsertNode(leafNode.asInserter());
@@ -74,6 +70,22 @@ public class LogisticsNetwork {
         if (leafNode.mode() == LeafNodeMode.EXTRACT) {
             this.onUnloadExtractNode(leafNode.asExtractor());
         }
+    }
+
+    /**
+     * Registers a loaded leaf node with this network without notifying other nodes.
+     * Used when reconstructing a network after graph changes so caches can be rebuilt afterwards.
+     */
+    public void trackLeafNode(LeafNodeBehaviour<?, ?> leafNode) {
+        var pos = leafNode.globalPos();
+        this.leafNodes.add(pos);
+        this.keyToLeafNodes.put(new Key(leafNode.capabilityType(), leafNode.frequency()), pos);
+    }
+
+    public void untrackLeafNode(LeafNodeBehaviour<?, ?> leafNode) {
+        var pos = leafNode.globalPos();
+        this.leafNodes.remove(pos);
+        this.keyToLeafNodes.remove(new Key(leafNode.capabilityType(), leafNode.frequency()), pos);
     }
 
     public <T, C> void onInserterNodeTargetAdded(GlobalPos targetPos, BlockCapabilityCache<T, C> capability, InserterNodeBehaviour<T, C> leafNode) {


### PR DESCRIPTION
## Summary
- forwardport the logistics network cache crash fix from #340 to version/26.1.2
- always rebuild caches when merging logistics networks instead of keeping the single-node merge shortcut
- track loaded leaf nodes while reconstructing networks so cache rebuilds see the full network state

## Validation
- ./gradlew.bat compileJava