### PR TITLE
refactor: adopt NeoForge EnergyHandler API for mercury flux

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.caloricfluxemitter;
 
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.network.Networking;
 import com.klikli_dev.theurgy.network.messages.MessageShowCaloricFlux;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -68,7 +68,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
             return;
         }
 
-        if (this.mercuryFluxHandler.getEnergyStored() >= FLUX_PER_HEAT) {
+        if (this.mercuryFluxHandler.getAmountAsInt() >= FLUX_PER_HEAT) {
             var heatReceiver = Objects.requireNonNull(this.level).getCapability(CapabilityRegistry.HEAT_RECEIVER, selectedPoint.getBlockPos(), selectedPoint.getBlockState(), null, null);
 
             if (!Objects.requireNonNull(heatReceiver).readyToReceive())
@@ -77,7 +77,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
             if (heatReceiver.getIsHotUntil() > this.getLevel().getGameTime() + TICK_INTERVAL)
                 return; //target block is still hot until next tick so do nothing
 
-            this.mercuryFluxHandler.extractEnergy(FLUX_PER_HEAT, false);
+            this.mercuryFluxHandler.extract(FLUX_PER_HEAT);
             heatReceiver.setHotUntil(this.getLevel().getGameTime() + HEAT_TARGET_FOR_TICKS);
 
             Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowCaloricFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(CaloricFluxEmitterBlock.FACING)));
@@ -119,7 +119,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
     protected void collectImplicitComponents(DataComponentMap.@NotNull Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
     }
 
     public SelectionBehaviour<CaloricFluxEmitterSelectedPoint> getSelectionBehaviour() {
@@ -141,15 +141,15 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         this.selectedPoints.forEach(point -> point.setLevel(this.getLevel()));
     }
 
-    public class CaloricFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
+    public class CaloricFluxEmitterMercuryFluxHandler extends SimpleMercuryFluxHandler {
 
         public CaloricFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
-            var received = super.receiveEnergy(maxReceive, simulate);
+        public int insert(int amount) {
+            var received = super.insert(amount);
 
             if (received > 0) {
                 CaloricFluxEmitterBlockEntity.this.setChanged();
@@ -159,8 +159,8 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
-            var extracted = super.extractEnergy(maxExtract, simulate);
+        public int extract(int amount) {
+            var extracted = super.extract(amount);
 
             if (extracted > 0) {
                 CaloricFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.caloricfluxemitter;
 
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
 import com.klikli_dev.theurgy.network.Networking;
 import com.klikli_dev.theurgy.network.messages.MessageShowCaloricFlux;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -36,14 +36,14 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
     public static final int HEAT_TARGET_FOR_TICKS = 20 * 6;
     public static final int TICK_INTERVAL = 20;
 
-    public MercuryFluxStorage mercuryFluxStorage;
+    public CaloricFluxEmitterMercuryFluxHandler mercuryFluxHandler;
 
     protected List<CaloricFluxEmitterSelectedPoint> selectedPoints;
 
     public CaloricFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super(BlockEntityRegistry.CALORIC_FLUX_EMITTER.get(), pPos, pBlockState);
 
-        this.mercuryFluxStorage = new MercuryFluxStorage(CAPACITY);
+        this.mercuryFluxHandler = new CaloricFluxEmitterMercuryFluxHandler(CAPACITY);
 
         this.selectedPoints = new ArrayList<>();
     }
@@ -68,7 +68,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
             return;
         }
 
-        if (this.mercuryFluxStorage.getEnergyStored() >= FLUX_PER_HEAT) {
+        if (this.mercuryFluxHandler.getEnergyStored() >= FLUX_PER_HEAT) {
             var heatReceiver = Objects.requireNonNull(this.level).getCapability(CapabilityRegistry.HEAT_RECEIVER, selectedPoint.getBlockPos(), selectedPoint.getBlockState(), null, null);
 
             if (!Objects.requireNonNull(heatReceiver).readyToReceive())
@@ -77,7 +77,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
             if (heatReceiver.getIsHotUntil() > this.getLevel().getGameTime() + TICK_INTERVAL)
                 return; //target block is still hot until next tick so do nothing
 
-            this.mercuryFluxStorage.extractEnergy(FLUX_PER_HEAT, false);
+            this.mercuryFluxHandler.extractEnergy(FLUX_PER_HEAT, false);
             heatReceiver.setHotUntil(this.getLevel().getGameTime() + HEAT_TARGET_FOR_TICKS);
 
             Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowCaloricFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(CaloricFluxEmitterBlock.FACING)));
@@ -89,10 +89,10 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
     protected void saveAdditional(@NotNull ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput storageOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(storageOutput);
+        ValueOutput storageOutput = output.child("mercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(storageOutput);
         if (storageOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("mercuryFluxHandler");
         }
 
         output.store("selectedPoints", CaloricFluxEmitterSelectedPoint.LIST_CODEC, this.selectedPoints);
@@ -102,7 +102,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
     public void loadAdditional(@NotNull ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("mercuryFluxStorage").ifPresent(this.mercuryFluxStorage::deserialize);
+        input.child("mercuryFluxHandler").ifPresent(this.mercuryFluxHandler::deserialize);
         this.selectedPoints = input.read("selectedPoints", CaloricFluxEmitterSelectedPoint.LIST_CODEC).orElseGet(ArrayList::new);
     }
 
@@ -112,14 +112,14 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxStorage.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override
     protected void collectImplicitComponents(DataComponentMap.@NotNull Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxStorage.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
     }
 
     public SelectionBehaviour<CaloricFluxEmitterSelectedPoint> getSelectionBehaviour() {
@@ -141,9 +141,9 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         this.selectedPoints.forEach(point -> point.setLevel(this.getLevel()));
     }
 
-    public class MercuryFluxStorage extends DefaultMercuryFluxStorage {
+    public class CaloricFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
 
-        public MercuryFluxStorage(int capacity) {
+        public CaloricFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
@@ -151,25 +151,8 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var received = super.insert(amount, transaction);
-
-            if (received > 0) {
-                CaloricFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return received;
-        }
-
-        @Override
-        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var extracted = super.extract(amount, transaction);
-
-            if (extracted > 0) {
-                CaloricFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return extracted;
+        protected void onEnergyChanged(int previousAmount) {
+            CaloricFluxEmitterBlockEntity.this.setChanged();
         }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
@@ -115,7 +115,7 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.set(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/caloricfluxemitter/CaloricFluxEmitterBlockEntity.java
@@ -77,7 +77,10 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
             if (heatReceiver.getIsHotUntil() > this.getLevel().getGameTime() + TICK_INTERVAL)
                 return; //target block is still hot until next tick so do nothing
 
-            this.mercuryFluxHandler.extract(FLUX_PER_HEAT);
+            try (net.neoforged.neoforge.transfer.transaction.Transaction tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                this.mercuryFluxHandler.extract(FLUX_PER_HEAT, tx);
+                tx.commit();
+            }
             heatReceiver.setHotUntil(this.getLevel().getGameTime() + HEAT_TARGET_FOR_TICKS);
 
             Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowCaloricFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(CaloricFluxEmitterBlock.FACING)));
@@ -148,8 +151,8 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int insert(int amount) {
-            var received = super.insert(amount);
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var received = super.insert(amount, transaction);
 
             if (received > 0) {
                 CaloricFluxEmitterBlockEntity.this.setChanged();
@@ -159,8 +162,8 @@ public class CaloricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int extract(int amount) {
-            var extracted = super.extract(amount);
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var extracted = super.extract(amount, transaction);
 
             if (extracted > 0) {
                 CaloricFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -6,8 +6,8 @@ package com.klikli_dev.theurgy.content.apparatus.logisticsmercuryfluxconnector;
 
 import com.klikli_dev.theurgy.content.behaviour.logistics.InserterNodeBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.logistics.LeafNodeMode;
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.logistics.Logistics;
 import com.klikli_dev.theurgy.registry.CapabilityRegistry;
 import net.minecraft.core.BlockPos;
@@ -34,7 +34,7 @@ import java.util.Set;
  * <p>
  * Flow: Source → Connector A buffer → (logistics network) → Connector B's attached block (sink)
  */
-public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviour<MercuryFluxStorage, @Nullable Direction> {
+public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviour<MercuryFluxHandler, @Nullable Direction> {
 
     public static final int DEFAULT_TRANSFER_RATE = 100;
     public static final int TRANSFER_EVERY_N_TICKS = 20; // 1 second
@@ -43,19 +43,19 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
     private final int slowTickRandomOffset = (int) (Math.random() * TRANSFER_EVERY_N_TICKS);
     private boolean enabled = true;
     private Direction directionOverride = null;
-    private final DefaultMercuryFluxStorage buffer;
+    private final SimpleMercuryHandler buffer;
 
     public LogisticsMercuryFluxConnectorBehaviour(BlockEntity blockEntity) {
         super(blockEntity, CapabilityRegistry.MERCURY_FLUX_HANDLER);
         // High maxReceive so source blocks can fill the buffer quickly
-        this.buffer = new DefaultMercuryFluxStorage(BUFFER_CAPACITY, BUFFER_CAPACITY, DEFAULT_TRANSFER_RATE);
+        this.buffer = new SimpleMercuryHandler(BUFFER_CAPACITY, BUFFER_CAPACITY, DEFAULT_TRANSFER_RATE);
     }
 
     /**
      * Returns the connector's internal flux buffer.
      * This is exposed via capability registration so source blocks can push into it.
      */
-    public MercuryFluxStorage buffer() {
+    public MercuryFluxHandler buffer() {
         return this.buffer;
     }
 
@@ -142,7 +142,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
         if (network == null) return;
 
         Set<GlobalPos> otherNodes = network.getLeafNodes(this.capabilityType(), this.frequency());
-        List<MercuryFluxStorage> sinks = new ArrayList<>();
+        List<MercuryFluxHandler> sinks = new ArrayList<>();
 
         for (var other : otherNodes) {
             if (other.equals(this.globalPos())) continue;
@@ -153,7 +153,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
 
             if (!otherConnector.enabled()) continue;
 
-            // Get the MercuryFluxStorage of the block the other connector is attached to (the sink)
+            // Get the MercuryFluxHandler of the block the other connector is attached to (the sink)
             var otherTargetCaps = otherConnector.availableTargetCapabilities();
             if (otherTargetCaps.isEmpty()) continue;
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.content.apparatus.logisticsmercuryfluxconnector;
 
 import com.klikli_dev.theurgy.content.behaviour.logistics.InserterNodeBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.logistics.LeafNodeMode;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.logistics.Logistics;
 import com.klikli_dev.theurgy.registry.CapabilityRegistry;
@@ -159,7 +158,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
             if (otherTargetCaps.isEmpty()) continue;
 
             var sinkCap = otherTargetCaps.getFirst().getCapability();
-            if (sinkCap != null && sinkCap.getAmountAsLong() < sinkCap.getCapacityAsLong()) {
+            if (sinkCap != null && this.canAcceptFlux(sinkCap)) {
                 sinks.add(sinkCap);
             }
         }
@@ -184,6 +183,12 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
                     tx.commit();
                 }
             }
+        }
+    }
+
+    private boolean canAcceptFlux(MercuryFluxHandler sinkCap) {
+        try (Transaction tx = Transaction.openRoot()) {
+            return sinkCap.insert(1, tx) > 0;
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -48,7 +48,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
 
     public LogisticsMercuryFluxConnectorBehaviour(BlockEntity blockEntity) {
         super(blockEntity, CapabilityRegistry.MERCURY_FLUX_HANDLER);
-        // High maxReceive so source blocks can fill the buffer quickly
+        // High maxInsert so source blocks can fill the buffer quickly
         this.buffer = new com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler(BUFFER_CAPACITY, BUFFER_CAPACITY, DEFAULT_TRANSFER_RATE);
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 /**
  * A leaf node behaviour that acts as a mercury flux conduit in the logistics network.
@@ -166,7 +167,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
         if (sinks.isEmpty()) return;
 
         // Distribute buffer contents evenly among all sinks (same pattern as MercuryCapacitor)
-        int totalToPush = this.buffer.simulateExtract(DEFAULT_TRANSFER_RATE * sinks.size());
+        int totalToPush = Math.min(this.buffer.getAmountAsInt(), DEFAULT_TRANSFER_RATE * sinks.size());
         if (totalToPush <= 0) return;
 
         int perTarget = totalToPush / sinks.size();
@@ -176,8 +177,13 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
 
-            int received = sinks.get(i).insert(amount);
-            this.buffer.extract(received);
+            try (Transaction tx = Transaction.openRoot()) {
+                int received = sinks.get(i).insert(amount, tx);
+                if (received > 0) {
+                    this.buffer.extract(received, tx);
+                    tx.commit();
+                }
+            }
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -158,7 +158,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
             if (otherTargetCaps.isEmpty()) continue;
 
             var sinkCap = otherTargetCaps.getFirst().getCapability();
-            if (sinkCap != null && sinkCap.canReceive()) {
+            if (sinkCap != null && sinkCap.getAmountAsLong() < sinkCap.getCapacityAsLong()) {
                 sinks.add(sinkCap);
             }
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBehaviour.java
@@ -6,7 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.logisticsmercuryfluxconnector;
 
 import com.klikli_dev.theurgy.content.behaviour.logistics.InserterNodeBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.logistics.LeafNodeMode;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.logistics.Logistics;
 import com.klikli_dev.theurgy.registry.CapabilityRegistry;
@@ -43,12 +43,12 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
     private final int slowTickRandomOffset = (int) (Math.random() * TRANSFER_EVERY_N_TICKS);
     private boolean enabled = true;
     private Direction directionOverride = null;
-    private final SimpleMercuryHandler buffer;
+    private final com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler buffer;
 
     public LogisticsMercuryFluxConnectorBehaviour(BlockEntity blockEntity) {
         super(blockEntity, CapabilityRegistry.MERCURY_FLUX_HANDLER);
         // High maxReceive so source blocks can fill the buffer quickly
-        this.buffer = new SimpleMercuryHandler(BUFFER_CAPACITY, BUFFER_CAPACITY, DEFAULT_TRANSFER_RATE);
+        this.buffer = new com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler(BUFFER_CAPACITY, BUFFER_CAPACITY, DEFAULT_TRANSFER_RATE);
     }
 
     /**
@@ -131,7 +131,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
      */
     public void tickServer() {
         if (!this.enabled) return;
-        if (this.buffer.getEnergyStored() <= 0) return;
+        if (this.buffer.getAmountAsInt() <= 0) return;
 
         // Slow tick to avoid processing every tick
         if ((this.slowTickRandomOffset + this.blockEntity.getLevel().getGameTime()) % TRANSFER_EVERY_N_TICKS != 0)
@@ -166,7 +166,7 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
         if (sinks.isEmpty()) return;
 
         // Distribute buffer contents evenly among all sinks (same pattern as MercuryCapacitor)
-        int totalToPush = this.buffer.extractEnergy(DEFAULT_TRANSFER_RATE * sinks.size(), true);
+        int totalToPush = this.buffer.simulateExtract(DEFAULT_TRANSFER_RATE * sinks.size());
         if (totalToPush <= 0) return;
 
         int perTarget = totalToPush / sinks.size();
@@ -176,8 +176,8 @@ public class LogisticsMercuryFluxConnectorBehaviour extends InserterNodeBehaviou
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
 
-            int received = sinks.get(i).receiveEnergy(amount, false);
-            this.buffer.extractEnergy(received, false);
+            int received = sinks.get(i).insert(amount);
+            this.buffer.extract(received);
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsmercuryfluxconnector/LogisticsMercuryFluxConnectorBlockEntity.java
@@ -6,7 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.logisticsmercuryfluxconnector;
 
 import com.klikli_dev.theurgy.content.apparatus.logisticsitemconnector.LogisticsItemConnectorBlock;
 import com.klikli_dev.theurgy.content.behaviour.logistics.HasLeafNodeBehaviour;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.item.mode.EnabledSetter;
 import com.klikli_dev.theurgy.content.item.mode.FrequencySetter;
 import com.klikli_dev.theurgy.content.item.mode.TargetDirectionSetter;
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LogisticsMercuryFluxConnectorBlockEntity extends BlockEntity implements HasLeafNodeBehaviour<MercuryFluxStorage, @Nullable Direction>, TargetDirectionSetter, EnabledSetter, FrequencySetter {
+public class LogisticsMercuryFluxConnectorBlockEntity extends BlockEntity implements HasLeafNodeBehaviour<MercuryFluxHandler, @Nullable Direction>, TargetDirectionSetter, EnabledSetter, FrequencySetter {
 
     protected LogisticsMercuryFluxConnectorBehaviour leafNodeBehaviour;
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlock.java
@@ -46,7 +46,7 @@ public class MercuryCapacitorBlock extends Block implements EntityBlock {
 
     public static int getBlockColor(@NotNull BlockState pState, @NotNull BlockAndTintGetter pLevel, @NotNull BlockPos pPos) {
         if (pLevel.getBlockEntity(pPos) instanceof MercuryCapacitorBlockEntity blockEntity) {
-            var fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
+            var fillLevel = blockEntity.mercuryFluxHandler.getAmountAsInt() / (float) blockEntity.mercuryFluxHandler.getCapacityAsInt();
 
             //if empty we return white, if full we should return blue: 0x0000FF
             return getColorFromFillLevel(fillLevel);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlock.java
@@ -46,7 +46,7 @@ public class MercuryCapacitorBlock extends Block implements EntityBlock {
 
     public static int getBlockColor(@NotNull BlockState pState, @NotNull BlockAndTintGetter pLevel, @NotNull BlockPos pPos) {
         if (pLevel.getBlockEntity(pPos) instanceof MercuryCapacitorBlockEntity blockEntity) {
-            var fillLevel = blockEntity.mercuryFluxStorage.getEnergyStored() / (float) blockEntity.mercuryFluxStorage.getMaxEnergyStored();
+            var fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
 
             //if empty we return white, if full we should return blue: 0x0000FF
             return getColorFromFillLevel(fillLevel);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -107,22 +107,22 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int insert(int amount) {
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
             var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
             // Only allow receiving if side is INPUT or BOTH
             if (mode != SideMode.INPUT && mode != SideMode.BOTH) {
                 return 0;
             }
-            return this.delegate.insert(amount);
+            return this.delegate.insert(amount, transaction);
         }
 
         @Override
-        public int extract(int amount) {
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
             var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
             if (mode != SideMode.OUTPUT && mode != SideMode.BOTH) {
                 return 0;
             }
-            return this.delegate.extract(amount);
+            return this.delegate.extract(amount, transaction);
         }
 
         public int getEnergyStored() {
@@ -267,7 +267,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxHandler.simulateExtract(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
+        int totalToPush = Math.min(this.mercuryFluxHandler.getAmountAsInt(), PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
         if (totalToPush <= 0) {
             return;
         }
@@ -280,9 +280,12 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
 
-            var received = targets.get(i).insert(amount);
-            if (received > 0) {
-                this.mercuryFluxHandler.extract(received);
+            try (net.neoforged.neoforge.transfer.transaction.Transaction tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                var received = targets.get(i).insert(amount, tx);
+                if (received > 0) {
+                    this.mercuryFluxHandler.extract(received, tx);
+                    tx.commit();
+                }
             }
         }
     }
@@ -340,8 +343,8 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int insert(int amount) {
-            var received = super.insert(amount);
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var received = super.insert(amount, transaction);
 
             if (received > 0) {
                 MercuryCapacitorBlockEntity.this.setChanged();
@@ -352,8 +355,8 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int extract(int amount) {
-            var extracted = super.extract(amount);
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var extracted = super.extract(amount, transaction);
 
             if (extracted > 0) {
                 MercuryCapacitorBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -125,32 +125,25 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
             return this.delegate.extractEnergy(maxExtract, simulate);
         }
 
-        @Override
         public int getEnergyStored() {
             return this.delegate.getEnergyStored();
         }
 
-        @Override
         public void setEnergyStored(int energy) {
             this.delegate.setEnergyStored(energy);
         }
 
-        @Override
         public int getMaxEnergyStored() {
             return this.delegate.getMaxEnergyStored();
         }
-
         @Override
-        public boolean canExtract() {
-            var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
-            return (mode == SideMode.OUTPUT || mode == SideMode.BOTH) && this.delegate.canExtract();
+        public long getAmountAsLong() {
+            return this.delegate.getAmountAsLong();
         }
 
         @Override
-        public boolean canReceive() {
-            var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
-            // Only allow receiving if side is INPUT or BOTH
-            return (mode == SideMode.INPUT || mode == SideMode.BOTH) && this.delegate.canReceive();
+        public long getCapacityAsLong() {
+            return this.delegate.getCapacityAsLong();
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -343,27 +343,9 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var received = super.insert(amount, transaction);
-
-            if (received > 0) {
-                MercuryCapacitorBlockEntity.this.setChanged();
-                this.trySendBlockUpdated();
-            }
-
-            return received;
-        }
-
-        @Override
-        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var extracted = super.extract(amount, transaction);
-
-            if (extracted > 0) {
-                MercuryCapacitorBlockEntity.this.setChanged();
-                this.trySendBlockUpdated();
-            }
-
-            return extracted;
+        protected void onEnergyChanged(int previousAmount) {
+            MercuryCapacitorBlockEntity.this.setChanged();
+            this.trySendBlockUpdated();
         }
 
         public void trySendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -182,7 +182,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     }
 
     public void readNetwork(ValueInput input) {
-        input.child("MercuryFluxHandler").ifPresent(value -> {
+        this.findMercuryFluxInput(input).ifPresent(value -> {
             this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
@@ -200,10 +200,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     }
 
     public void writeNetwork(ValueOutput output) {
-        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        ValueOutput fluxOutput = output.child("mercuryFluxHandler");
         this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("MercuryFluxHandler");
+            output.discard("mercuryFluxHandler");
         }
 
         ValueOutput sideModesOutput = output.child("sideModes");
@@ -280,10 +280,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        ValueOutput fluxOutput = output.child("mercuryFluxHandler");
         this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("MercuryFluxHandler");
+            output.discard("mercuryFluxHandler");
         }
     }
 
@@ -291,7 +291,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         input.child("sideModes").ifPresent(child -> {
             for (var direction : Direction.values()) {
@@ -317,6 +317,12 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         super.collectImplicitComponents(pComponents);
 
         pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
+    }
+
+    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
+        return input.child("mercuryFluxHandler")
+                .or(() -> input.child("MercuryFluxHandler"))
+                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     public class MercuryCapacitorMercuryFluxHandler extends SimpleMercuryFluxHandler {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -4,7 +4,7 @@
 
 package com.klikli_dev.theurgy.content.apparatus.mercurycapacitor;
 
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.item.mode.SideModeSetter;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -107,35 +107,38 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
+        public int insert(int amount) {
             var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
             // Only allow receiving if side is INPUT or BOTH
             if (mode != SideMode.INPUT && mode != SideMode.BOTH) {
                 return 0;
             }
-            return this.delegate.receiveEnergy(maxReceive, simulate);
+            return this.delegate.insert(amount);
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
+        public int extract(int amount) {
             var mode = MercuryCapacitorBlockEntity.this.getSideMode(this.side);
             if (mode != SideMode.OUTPUT && mode != SideMode.BOTH) {
                 return 0;
             }
-            return this.delegate.extractEnergy(maxExtract, simulate);
+            return this.delegate.extract(amount);
         }
 
         public int getEnergyStored() {
-            return this.delegate.getEnergyStored();
+            return this.delegate.getAmountAsInt();
         }
 
         public void setEnergyStored(int energy) {
-            this.delegate.setEnergyStored(energy);
+            if (this.delegate instanceof SimpleMercuryFluxHandler smh) {
+                smh.setEnergyStored(energy);
+            }
         }
 
         public int getMaxEnergyStored() {
-            return this.delegate.getMaxEnergyStored();
+            return this.delegate.getCapacityAsInt();
         }
+
         @Override
         public long getAmountAsLong() {
             return this.delegate.getAmountAsLong();
@@ -264,7 +267,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxHandler.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
+        int totalToPush = this.mercuryFluxHandler.simulateExtract(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
         if (totalToPush <= 0) {
             return;
         }
@@ -277,8 +280,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
 
-            var received = targets.get(i).receiveEnergy(amount, false);
-            this.mercuryFluxHandler.extractEnergy(received, false);
+            var received = targets.get(i).insert(amount);
+            if (received > 0) {
+                this.mercuryFluxHandler.extract(received);
+            }
         }
     }
 
@@ -297,7 +302,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("MercuryFluxHandler").ifPresent(this.mercuryFluxHandler::deserialize);
+        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         input.child("sideModes").ifPresent(child -> {
             for (var direction : Direction.values()) {
@@ -322,10 +327,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
     }
 
-    public class MercuryCapacitorMercuryFluxHandler extends SimpleMercuryHandler {
+    public class MercuryCapacitorMercuryFluxHandler extends SimpleMercuryFluxHandler {
 
         public static final int UPDATE_THRESHOLD = 1000;
         private int lastUpdateLevel;
@@ -335,8 +340,8 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
-            var received = super.receiveEnergy(maxReceive, simulate);
+        public int insert(int amount) {
+            var received = super.insert(amount);
 
             if (received > 0) {
                 MercuryCapacitorBlockEntity.this.setChanged();
@@ -347,8 +352,8 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
-            var extracted = super.extractEnergy(maxExtract, simulate);
+        public int extract(int amount) {
+            var extracted = super.extract(amount);
 
             if (extracted > 0) {
                 MercuryCapacitorBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -4,8 +4,8 @@
 
 package com.klikli_dev.theurgy.content.apparatus.mercurycapacitor;
 
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.item.mode.SideModeSetter;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.CapabilityRegistry;
@@ -45,12 +45,12 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public static final int PUSH_TICK_INTERVAL = 20;
     public static final int PUSH_RATE_PER_SIDE_PER_TICK = 2;
 
-    public MercuryCapacitorMercuryFluxStorage mercuryFluxStorage;
+    public MercuryCapacitorMercuryFluxHandler mercuryFluxHandler;
 
     /**
      * Pre-constructed side-aware storage wrappers for each direction.
      */
-    private final Map<Direction, MercuryFluxStorage> sideAwareStorages = new EnumMap<>(Direction.class);
+    private final Map<Direction, MercuryFluxHandler> sideAwareStorages = new EnumMap<>(Direction.class);
 
     /**
      * Side configuration for each direction. Default is NONE (no interaction).
@@ -60,11 +60,11 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public MercuryCapacitorBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super(BlockEntityRegistry.MERCURY_CAPACITOR.get(), pPos, pBlockState);
 
-        this.mercuryFluxStorage = new MercuryCapacitorMercuryFluxStorage(CAPACITY);
+        this.mercuryFluxHandler = new MercuryCapacitorMercuryFluxHandler(CAPACITY);
 
         // Pre-construct side-aware storage wrappers
         for (var direction : Direction.values()) {
-            this.sideAwareStorages.put(direction, new SideAwareMercuryFluxStorage(this.mercuryFluxStorage, direction));
+            this.sideAwareStorages.put(direction, new SideAwareMercuryFluxHandler(this.mercuryFluxHandler, direction));
         }
 
         // Default: TOP and BOTTOM are OUTPUT (push flux up/down), other sides are INPUT (receive flux)
@@ -87,21 +87,21 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
      * Returns a mercury flux storage wrapper that respects side mode for receiving.
      * If side is null, returns the full storage (for internal use).
      */
-    public MercuryFluxStorage getMercuryFluxStorage(@Nullable Direction side) {
+    public MercuryFluxHandler getMercuryFluxHandler(@Nullable Direction side) {
         if (side == null) {
-            return this.mercuryFluxStorage;
+            return this.mercuryFluxHandler;
         }
-        return this.sideAwareStorages.getOrDefault(side, this.mercuryFluxStorage);
+        return this.sideAwareStorages.getOrDefault(side, this.mercuryFluxHandler);
     }
 
     /**
      * Wrapper that enforces side mode on receive operations.
      */
-    private class SideAwareMercuryFluxStorage implements MercuryFluxStorage {
-        private final MercuryFluxStorage delegate;
+    private class SideAwareMercuryFluxHandler implements MercuryFluxHandler {
+        private final MercuryFluxHandler delegate;
         private final Direction side;
 
-        public SideAwareMercuryFluxStorage(MercuryFluxStorage delegate, Direction side) {
+        public SideAwareMercuryFluxHandler(MercuryFluxHandler delegate, Direction side) {
             this.delegate = delegate;
             this.side = side;
         }
@@ -200,8 +200,8 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     }
 
     public void readNetwork(ValueInput input) {
-        input.child("mercuryFluxStorage").ifPresent(value -> {
-            this.mercuryFluxStorage.deserialize(value);
+        input.child("MercuryFluxHandler").ifPresent(value -> {
+            this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
             }
@@ -218,10 +218,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     }
 
     public void writeNetwork(ValueOutput output) {
-        ValueOutput fluxOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(fluxOutput);
+        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("MercuryFluxHandler");
         }
 
         ValueOutput sideModesOutput = output.child("sideModes");
@@ -252,7 +252,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     protected void pushMercuryFlux() {
         // Collect only sides that have OUTPUT or BOTH mode
         var directions = Direction.allShuffled(this.getLevel().getRandom());
-        var targets = new ArrayList<MercuryFluxStorage>();
+        var targets = new ArrayList<MercuryFluxHandler>();
 
         for (var direction : directions) {
             var mode = this.getSideMode(direction);
@@ -271,7 +271,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxStorage.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
+        int totalToPush = this.mercuryFluxHandler.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
         if (totalToPush <= 0) {
             return;
         }
@@ -285,7 +285,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
             if (amount <= 0) continue;
 
             var received = targets.get(i).receiveEnergy(amount, false);
-            this.mercuryFluxStorage.extractEnergy(received, false);
+            this.mercuryFluxHandler.extractEnergy(received, false);
         }
     }
 
@@ -293,10 +293,10 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput fluxOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(fluxOutput);
+        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("MercuryFluxHandler");
         }
     }
 
@@ -304,7 +304,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("mercuryFluxStorage").ifPresent(this.mercuryFluxStorage::deserialize);
+        input.child("MercuryFluxHandler").ifPresent(this.mercuryFluxHandler::deserialize);
 
         input.child("sideModes").ifPresent(child -> {
             for (var direction : Direction.values()) {
@@ -322,22 +322,22 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxStorage.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxStorage.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
     }
 
-    public class MercuryCapacitorMercuryFluxStorage extends DefaultMercuryFluxStorage {
+    public class MercuryCapacitorMercuryFluxHandler extends SimpleMercuryHandler {
 
         public static final int UPDATE_THRESHOLD = 1000;
         private int lastUpdateLevel;
 
-        public MercuryCapacitorMercuryFluxStorage(int capacity) {
+        public MercuryCapacitorMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -125,20 +125,6 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
             return this.delegate.extract(amount, transaction);
         }
 
-        public int getEnergyStored() {
-            return this.delegate.getAmountAsInt();
-        }
-
-        public void setEnergyStored(int energy) {
-            if (this.delegate instanceof SimpleMercuryFluxHandler smh) {
-                smh.setEnergyStored(energy);
-            }
-        }
-
-        public int getMaxEnergyStored() {
-            return this.delegate.getCapacityAsInt();
-        }
-
         @Override
         public long getAmountAsLong() {
             return this.delegate.getAmountAsLong();
@@ -323,7 +309,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.set(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override
@@ -349,7 +335,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         }
 
         public void trySendBlockUpdated() {
-            var currentLevel = this.getEnergyStored();
+            var currentLevel = this.getAmountAsInt();
             if (Math.abs(this.lastUpdateLevel - currentLevel) > UPDATE_THRESHOLD) {
                 this.lastUpdateLevel = currentLevel;
                 MercuryCapacitorBlockEntity.this.sendBlockUpdated();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/MercuryCapacitorBlockEntity.java
@@ -182,7 +182,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     }
 
     public void readNetwork(ValueInput input) {
-        this.findMercuryFluxInput(input).ifPresent(value -> {
+        input.child("mercuryFluxHandler").ifPresent(value -> {
             this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
@@ -291,7 +291,7 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        input.child("mercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         input.child("sideModes").ifPresent(child -> {
             for (var direction : Direction.values()) {
@@ -317,12 +317,6 @@ public class MercuryCapacitorBlockEntity extends BlockEntity implements SideMode
         super.collectImplicitComponents(pComponents);
 
         pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
-    }
-
-    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
-        return input.child("mercuryFluxHandler")
-                .or(() -> input.child("MercuryFluxHandler"))
-                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     public class MercuryCapacitorMercuryFluxHandler extends SimpleMercuryFluxHandler {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/render/MercuryCapacitorRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/render/MercuryCapacitorRenderer.java
@@ -49,8 +49,8 @@ public class MercuryCapacitorRenderer implements BlockEntityRenderer<MercuryCapa
     ) {
         BlockEntityRenderer.super.extractRenderState(blockEntity, state, partialTick, cameraPosition, breakProgress);
 
-        float fillLevel = blockEntity.mercuryFluxStorage.getEnergyStored() / (float) blockEntity.mercuryFluxStorage.getMaxEnergyStored();
-        state.hasEnergy = blockEntity.mercuryFluxStorage.getEnergyStored() > 0;
+        float fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
+        state.hasEnergy = blockEntity.mercuryFluxHandler.getEnergyStored() > 0;
         state.particleColor = MercuryCapacitorBlock.getParticleColorFromFillLevel(fillLevel);
         state.cameraPosition = cameraPosition;
         state.blockPos = blockEntity.getBlockPos();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/render/MercuryCapacitorRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycapacitor/render/MercuryCapacitorRenderer.java
@@ -49,8 +49,8 @@ public class MercuryCapacitorRenderer implements BlockEntityRenderer<MercuryCapa
     ) {
         BlockEntityRenderer.super.extractRenderState(blockEntity, state, partialTick, cameraPosition, breakProgress);
 
-        float fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
-        state.hasEnergy = blockEntity.mercuryFluxHandler.getEnergyStored() > 0;
+        float fillLevel = blockEntity.mercuryFluxHandler.getAmountAsInt() / (float) blockEntity.mercuryFluxHandler.getCapacityAsInt();
+        state.hasEnergy = blockEntity.mercuryFluxHandler.getAmountAsInt() > 0;
         state.particleColor = MercuryCapacitorBlock.getParticleColorFromFillLevel(fillLevel);
         state.cameraPosition = cameraPosition;
         state.blockPos = blockEntity.getBlockPos();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlock.java
@@ -51,7 +51,7 @@ public class MercuryCatalystBlock extends Block implements EntityBlock {
 
     public static int getBlockColor(@NotNull BlockState pState, @NotNull BlockAndTintGetter pLevel, @NotNull BlockPos pPos) {
         if (pLevel.getBlockEntity(pPos) instanceof MercuryCatalystBlockEntity blockEntity) {
-            var fillLevel = blockEntity.mercuryFluxStorage.getEnergyStored() / (float) blockEntity.mercuryFluxStorage.getMaxEnergyStored();
+            var fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
 
             //if empty we return white, if full we should return blue: 0x0000FF
             return getColorFromFillLevel(fillLevel);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlock.java
@@ -51,7 +51,7 @@ public class MercuryCatalystBlock extends Block implements EntityBlock {
 
     public static int getBlockColor(@NotNull BlockState pState, @NotNull BlockAndTintGetter pLevel, @NotNull BlockPos pPos) {
         if (pLevel.getBlockEntity(pPos) instanceof MercuryCatalystBlockEntity blockEntity) {
-            var fillLevel = blockEntity.mercuryFluxHandler.getEnergyStored() / (float) blockEntity.mercuryFluxHandler.getMaxEnergyStored();
+            var fillLevel = blockEntity.mercuryFluxHandler.getAmountAsInt() / (float) blockEntity.mercuryFluxHandler.getCapacityAsInt();
 
             //if empty we return white, if full we should return blue: 0x0000FF
             return getColorFromFillLevel(fillLevel);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -137,7 +137,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
         
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxHandler.simulateExtract(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
+        int totalToPush = Math.min(this.mercuryFluxHandler.getAmountAsInt(), PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
         if (totalToPush <= 0) {
             return;
         }
@@ -150,9 +150,12 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
             
-            var received = targets.get(i).insert(amount);
-            if (received > 0) {
-                this.mercuryFluxHandler.extract(received);
+            try (net.neoforged.neoforge.transfer.transaction.Transaction tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                var received = targets.get(i).insert(amount, tx);
+                if (received > 0) {
+                    this.mercuryFluxHandler.extract(received, tx);
+                    tx.commit();
+                }
             }
         }
     }
@@ -251,7 +254,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         @Override
-        public int insert(int amount) {
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
             // Do not receive any external flux - only internal generation
             return 0;
         }
@@ -274,8 +277,8 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         @Override
-        public int extract(int amount) {
-            var extracted = super.extract(amount);
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var extracted = super.extract(amount, transaction);
 
             if (extracted > 0) {
                 MercuryCatalystBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -195,7 +195,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.set(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()) != null)
             ValueIOUtils.deserialize(this.level.registryAccess(), this.inventory, pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()).copyTag());

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -7,8 +7,8 @@ package com.klikli_dev.theurgy.content.apparatus.mercurycatalyst;
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.HasCraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.LevelAwareCachedCheck;
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.render.HeldStackFitProvider;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
@@ -49,7 +49,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     public static final int PUSH_RATE_PER_SIDE_PER_TICK = 2;
 
     public MonitoredItemStackHandler inventory;
-    public MercuryCatalystMercuryFluxStorage mercuryFluxStorage;
+    public MercuryCatalystMercuryFluxHandler mercuryFluxHandler;
 
     protected MercuryCatalystCraftingBehaviour craftingBehaviour;
 
@@ -58,10 +58,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
 
         this.inventory = new Inventory();
 
-        this.mercuryFluxStorage = new MercuryCatalystMercuryFluxStorage(CAPACITY);
+        this.mercuryFluxHandler = new MercuryCatalystMercuryFluxHandler(CAPACITY);
 
 
-        this.craftingBehaviour = new MercuryCatalystCraftingBehaviour(this, () -> this.inventory, () -> this.inventory, () -> this.mercuryFluxStorage);
+        this.craftingBehaviour = new MercuryCatalystCraftingBehaviour(this, () -> this.inventory, () -> this.inventory, () -> this.mercuryFluxHandler);
     }
 
     @Override
@@ -86,8 +86,8 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     }
 
     public void readNetwork(ValueInput input) {
-        input.child("mercuryFluxStorage").ifPresent(value -> {
-            this.mercuryFluxStorage.deserialize(value);
+        input.child("MercuryFluxHandler").ifPresent(value -> {
+            this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
             }
@@ -95,10 +95,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     }
 
     public void writeNetwork(ValueOutput output) {
-        ValueOutput fluxOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(fluxOutput);
+        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("MercuryFluxHandler");
         }
     }
 
@@ -122,7 +122,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     protected void pushMercuryFlux() {
         // Collect all valid flux handlers first
         var directions = Direction.allShuffled(this.getLevel().getRandom());
-        var targets = new ArrayList<MercuryFluxStorage>();
+        var targets = new ArrayList<MercuryFluxHandler>();
         
         for (var direction : directions) {
             var fluxStorage = this.level.getCapability(CapabilityRegistry.MERCURY_FLUX_HANDLER, this.getBlockPos().relative(direction), direction.getOpposite());
@@ -136,7 +136,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
         
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxStorage.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
+        int totalToPush = this.mercuryFluxHandler.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
         if (totalToPush <= 0) {
             return;
         }
@@ -150,7 +150,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             if (amount <= 0) continue;
             
             var received = targets.get(i).receiveEnergy(amount, false);
-            this.mercuryFluxStorage.extractEnergy(received, false);
+            this.mercuryFluxHandler.extractEnergy(received, false);
         }
     }
 
@@ -164,10 +164,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             output.discard("inventory");
         }
 
-        ValueOutput fluxOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(fluxOutput);
+        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("MercuryFluxHandler");
         }
 
         this.craftingBehaviour.saveAdditional(output);
@@ -178,7 +178,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         super.loadAdditional(input);
 
         input.child("inventory").ifPresent(this.inventory::deserialize);
-        input.child("mercuryFluxStorage").ifPresent(this.mercuryFluxStorage::deserialize);
+        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         this.craftingBehaviour.loadAdditional(input);
     }
@@ -189,7 +189,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
             //noinspection DataFlowIssue
-            this.mercuryFluxStorage.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()) != null)
             ValueIOUtils.deserialize(this.level.registryAccess(), this.inventory, pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()).copyTag());
@@ -201,7 +201,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxStorage.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
 
         pComponents.set(DataComponentRegistry.MERCURY_CATALYST_INVENTORY, CustomData.of(ValueIOUtils.serialize(this.level.registryAccess(), this.inventory)));
 
@@ -237,12 +237,12 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
     }
 
-    public class MercuryCatalystMercuryFluxStorage extends DefaultMercuryFluxStorage {
+    public class MercuryCatalystMercuryFluxHandler extends SimpleMercuryHandler {
 
         public static final int UPDATE_THRESHOLD = 100;
         private int lastUpdateLevel;
 
-        public MercuryCatalystMercuryFluxStorage(int capacity) {
+        public MercuryCatalystMercuryFluxHandler(int capacity) {
             // Non-receiving: only internal flux generation can fill this storage
             super(capacity, 0, capacity);
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -277,15 +277,9 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         @Override
-        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var extracted = super.extract(amount, transaction);
-
-            if (extracted > 0) {
-                MercuryCatalystBlockEntity.this.setChanged();
-                this.trySendBlockUpdated();
-            }
-
-            return extracted;
+        protected void onEnergyChanged(int previousAmount) {
+            MercuryCatalystBlockEntity.this.setChanged();
+            this.trySendBlockUpdated();
         }
 
         public void trySendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -7,7 +7,8 @@ package com.klikli_dev.theurgy.content.apparatus.mercurycatalyst;
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.HasCraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.LevelAwareCachedCheck;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.render.HeldStackFitProvider;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
@@ -61,7 +62,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         this.mercuryFluxHandler = new MercuryCatalystMercuryFluxHandler(CAPACITY);
 
 
-        this.craftingBehaviour = new MercuryCatalystCraftingBehaviour(this, () -> this.inventory, () -> this.inventory, () -> this.mercuryFluxHandler);
+        this.craftingBehaviour = new MercuryCatalystCraftingBehaviour(this, () -> this.inventory, () -> this.inventory, () -> (MercuryFluxHandler) this.mercuryFluxHandler);
     }
 
     @Override
@@ -136,7 +137,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
         
         // Calculate how much to push to each target (scale by number of targets to maintain throughput)
-        int totalToPush = this.mercuryFluxHandler.extractEnergy(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size(), true);
+        int totalToPush = this.mercuryFluxHandler.simulateExtract(PUSH_RATE_PER_SIDE_PER_TICK * PUSH_TICK_INTERVAL * targets.size());
         if (totalToPush <= 0) {
             return;
         }
@@ -149,8 +150,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             int amount = perTarget + (i < remainder ? 1 : 0);
             if (amount <= 0) continue;
             
-            var received = targets.get(i).receiveEnergy(amount, false);
-            this.mercuryFluxHandler.extractEnergy(received, false);
+            var received = targets.get(i).insert(amount);
+            if (received > 0) {
+                this.mercuryFluxHandler.extract(received);
+            }
         }
     }
 
@@ -201,7 +204,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
+            pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
 
         pComponents.set(DataComponentRegistry.MERCURY_CATALYST_INVENTORY, CustomData.of(ValueIOUtils.serialize(this.level.registryAccess(), this.inventory)));
 
@@ -237,7 +240,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
     }
 
-    public class MercuryCatalystMercuryFluxHandler extends SimpleMercuryHandler {
+    public class MercuryCatalystMercuryFluxHandler extends SimpleMercuryFluxHandler {
 
         public static final int UPDATE_THRESHOLD = 100;
         private int lastUpdateLevel;
@@ -248,20 +251,21 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
+        public int insert(int amount) {
             // Do not receive any external flux - only internal generation
             return 0;
         }
 
         /**
          * Internal method for the crafting behaviour to add flux generated from processing.
-         * This bypasses the non-receiving restriction.
+         * This bypasses the non-receiving restriction by directly modifying energy.
          */
         public int addInternalFlux(int amount) {
-            int energyReceived = Math.min(this.capacity - this.energy, amount);
-            this.energy += energyReceived;
+            int spaceAvailable = this.capacity - this.energy;
+            int energyReceived = Math.min(spaceAvailable, amount);
             
             if (energyReceived > 0) {
+                this.energy += energyReceived;
                 MercuryCatalystBlockEntity.this.setChanged();
                 this.trySendBlockUpdated();
             }
@@ -270,8 +274,8 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
-            var extracted = super.extractEnergy(maxExtract, simulate);
+        public int extract(int amount) {
+            var extracted = super.extract(amount);
 
             if (extracted > 0) {
                 MercuryCatalystBlockEntity.this.setChanged();
@@ -282,7 +286,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         }
 
         public void trySendBlockUpdated() {
-            var currentLevel = this.getEnergyStored();
+            var currentLevel = this.getAmountAsInt();
             if (Math.abs(this.lastUpdateLevel - currentLevel) > UPDATE_THRESHOLD) {
                 this.lastUpdateLevel = currentLevel;
                 MercuryCatalystBlockEntity.this.sendBlockUpdated();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -86,7 +86,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     }
 
     public void readNetwork(ValueInput input) {
-        this.findMercuryFluxInput(input).ifPresent(value -> {
+        input.child("mercuryFluxHandler").ifPresent(value -> {
             this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
@@ -183,7 +183,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         super.loadAdditional(input);
 
         input.child("inventory").ifPresent(this.inventory::deserialize);
-        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        input.child("mercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         this.craftingBehaviour.loadAdditional(input);
     }
@@ -200,12 +200,6 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             ValueIOUtils.deserialize(this.level.registryAccess(), this.inventory, pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()).copyTag());
 
         this.craftingBehaviour.applyImplicitComponents(pComponentInput);
-    }
-
-    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
-        return input.child("mercuryFluxHandler")
-                .or(() -> input.child("MercuryFluxHandler"))
-                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -7,9 +7,8 @@ package com.klikli_dev.theurgy.content.apparatus.mercurycatalyst;
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.HasCraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.LevelAwareCachedCheck;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.render.HeldStackFitProvider;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
@@ -87,7 +86,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     }
 
     public void readNetwork(ValueInput input) {
-        input.child("MercuryFluxHandler").ifPresent(value -> {
+        this.findMercuryFluxInput(input).ifPresent(value -> {
             this.mercuryFluxHandler.deserialize(value);
             if (this.level != null) {
                 this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_IMMEDIATE);
@@ -96,10 +95,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
     }
 
     public void writeNetwork(ValueOutput output) {
-        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        ValueOutput fluxOutput = output.child("mercuryFluxHandler");
         this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("MercuryFluxHandler");
+            output.discard("mercuryFluxHandler");
         }
     }
 
@@ -170,10 +169,10 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             output.discard("inventory");
         }
 
-        ValueOutput fluxOutput = output.child("MercuryFluxHandler");
+        ValueOutput fluxOutput = output.child("mercuryFluxHandler");
         this.mercuryFluxHandler.serialize(fluxOutput);
         if (fluxOutput.isEmpty()) {
-            output.discard("MercuryFluxHandler");
+            output.discard("mercuryFluxHandler");
         }
 
         this.craftingBehaviour.saveAdditional(output);
@@ -184,7 +183,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
         super.loadAdditional(input);
 
         input.child("inventory").ifPresent(this.inventory::deserialize);
-        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
 
         this.craftingBehaviour.loadAdditional(input);
     }
@@ -201,6 +200,12 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements HeldStack
             ValueIOUtils.deserialize(this.level.registryAccess(), this.inventory, pComponentInput.get(DataComponentRegistry.MERCURY_CATALYST_INVENTORY.get()).copyTag());
 
         this.craftingBehaviour.applyImplicitComponents(pComponentInput);
+    }
+
+    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
+        return input.child("mercuryFluxHandler")
+                .or(() -> input.child("MercuryFluxHandler"))
+                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystCraftingBehaviour.java
@@ -112,7 +112,7 @@ public class MercuryCatalystCraftingBehaviour extends CraftingBehaviour<ItemHand
 
         var handler = this.mercuryFluxHandlerSupplier.get();
         // Check if there's any room available to start the process
-        return handler.getEnergyStored() < handler.getMaxEnergyStored();
+        return handler.getAmountAsInt() < handler.getCapacityAsInt();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystCraftingBehaviour.java
@@ -6,7 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.mercurycatalyst;
 
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.LevelAwareCachedCheck;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.recipe.CatalysationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ItemHandlerRecipeInput;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 
 public class MercuryCatalystCraftingBehaviour extends CraftingBehaviour<ItemHandlerRecipeInput, CatalysationRecipe, LevelAwareCachedCheck<ItemHandlerRecipeInput, CatalysationRecipe>> {
 
-    private final Supplier<MercuryFluxStorage> mercuryFluxStorageSupplier;
+    private final Supplier<MercuryFluxHandler> mercuryFluxHandlerSupplier;
     private final MonitoredItemStackHandler ingredientCheckInventory = new MonitoredItemStackHandler() {
     };
     private final ItemHandlerRecipeInput ingredientCheckInput = new ItemHandlerRecipeInput(this.ingredientCheckInventory);
@@ -37,14 +37,14 @@ public class MercuryCatalystCraftingBehaviour extends CraftingBehaviour<ItemHand
     protected int currentMercuryFluxPerTick;
 
 
-    public MercuryCatalystCraftingBehaviour(BlockEntity blockEntity, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxStorage> mercuryFluxStorageSupplier) {
+    public MercuryCatalystCraftingBehaviour(BlockEntity blockEntity, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxHandler> mercuryFluxHandlerSupplier) {
         super(blockEntity,
                 Lazy.of(() -> new ItemHandlerRecipeInput(inputInventorySupplier.get())),
                 inputInventorySupplier,
                 outputInventorySupplier,
                 new LevelAwareCachedCheck<>(RecipeTypeRegistry.CATALYSATION.get()));
 
-        this.mercuryFluxStorageSupplier = mercuryFluxStorageSupplier;
+        this.mercuryFluxHandlerSupplier = mercuryFluxHandlerSupplier;
     }
 
     @Override
@@ -110,9 +110,9 @@ public class MercuryCatalystCraftingBehaviour extends CraftingBehaviour<ItemHand
     public boolean canCraft(@Nullable RecipeHolder<CatalysationRecipe> pRecipe) {
         if (pRecipe == null) return false;
 
-        var storage = this.mercuryFluxStorageSupplier.get();
+        var handler = this.mercuryFluxHandlerSupplier.get();
         // Check if there's any room available to start the process
-        return storage.getEnergyStored() < storage.getMaxEnergyStored();
+        return handler.getEnergyStored() < handler.getMaxEnergyStored();
     }
 
     @Override
@@ -121,10 +121,10 @@ public class MercuryCatalystCraftingBehaviour extends CraftingBehaviour<ItemHand
         if (this.mercuryFluxToConvert > 0) {
             if (canProcess) {
                 this.tryStartProcessing(); // Mark as processing for HUD
-                var storage = this.mercuryFluxStorageSupplier.get();
+                var handler = this.mercuryFluxHandlerSupplier.get();
                 var maxFluxToConvert = Math.min(this.mercuryFluxToConvert, this.currentMercuryFluxPerTick);
                 // Use addInternalFlux for internal crafting flux generation
-                int fluxAdded = ((MercuryCatalystBlockEntity.MercuryCatalystMercuryFluxStorage) storage).addInternalFlux(maxFluxToConvert);
+                int fluxAdded = ((MercuryCatalystBlockEntity.MercuryCatalystMercuryFluxHandler) handler).addInternalFlux(maxFluxToConvert);
                 this.mercuryFluxToConvert -= fluxAdded;
             }
         } else if (hasInput) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 public class MercuryFluxEmitterBlockEntity extends BlockEntity {
 
@@ -99,13 +100,19 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
             if (accepted <= 0)
                 return;
 
-            int extracted = this.mercuryFluxHandler.extract(accepted);
-            if (extracted > 0) {
-                int inserted = targetFluxHandler.insert(extracted);
-                if (inserted <= 0)
-                    return;
+            try (net.neoforged.neoforge.transfer.transaction.Transaction tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                int extracted = this.mercuryFluxHandler.extract(accepted, tx);
+                if (extracted > 0) {
+                    int inserted = targetFluxHandler.insert(extracted, tx);
+                    if (inserted <= 0) {
+                        // nothing accepted, abort
+                        return;
+                    }
+                    // commit the transfer
+                    tx.commit();
 
-                Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowMercuryFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(MercuryFluxEmitterBlock.FACING)));
+                    Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowMercuryFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(MercuryFluxEmitterBlock.FACING)));
+                }
             }
         }
     }
@@ -203,8 +210,8 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         @Override
-        public int insert(int amount) {
-            var received = super.insert(amount);
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var received = super.insert(amount, transaction);
 
             if (received > 0) {
                 MercuryFluxEmitterBlockEntity.this.setChanged();
@@ -214,8 +221,8 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         @Override
-        public int extract(int amount) {
-            var extracted = super.extract(amount);
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var extracted = super.extract(amount, transaction);
 
             if (extracted > 0) {
                 MercuryFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -173,7 +173,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super.applyImplicitComponents(pComponentInput);
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null) {
-            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.set(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
 import com.klikli_dev.theurgy.network.Networking;
 import com.klikli_dev.theurgy.network.messages.MessageShowMercuryFlux;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -42,14 +42,14 @@ public class MercuryFluxEmitterBlockEntity extends BlockEntity {
     public static final int FLUX_PER_TRANSFER = 10;
     public static final int TICK_INTERVAL = 20;
 
-    public MercuryFluxStorage mercuryFluxStorage;
+    public MercuryFluxEmitterMercuryFluxHandler mercuryFluxHandler;
 
     protected List<MercuryFluxEmitterSelectedPoint> selectedPoints;
 
 public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super(BlockEntityRegistry.MERCURY_FLUX_EMITTER.get(), pPos, pBlockState);
 
-        this.mercuryFluxStorage = new MercuryFluxStorage(CAPACITY);
+        this.mercuryFluxHandler = new MercuryFluxEmitterMercuryFluxHandler(CAPACITY);
 
         this.selectedPoints = new ArrayList<>();
     }
@@ -80,7 +80,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         // Transfer to target if we have flux
-        if (this.mercuryFluxStorage.getEnergyStored() >= FLUX_PER_TRANSFER) {
+        if (this.mercuryFluxHandler.getEnergyStored() >= FLUX_PER_TRANSFER) {
             var targetPos = selectedPoint.getBlockPos();
             var targetState = selectedPoint.getBlockState();
 
@@ -99,7 +99,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
             if (accepted <= 0)
                 return;
 
-            int extracted = this.mercuryFluxStorage.extractEnergy(accepted, false);
+            int extracted = this.mercuryFluxHandler.extractEnergy(accepted, false);
             if (extracted > 0) {
                 int inserted = targetFluxHandler.receiveEnergy(extracted, false);
                 if (inserted <= 0)
@@ -114,10 +114,10 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
     protected void saveAdditional(@NotNull ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput storageOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(storageOutput);
+        ValueOutput storageOutput = output.child("mercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(storageOutput);
         if (storageOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("mercuryFluxHandler");
         }
 
         output.store("selectedPoints", MercuryFluxEmitterSelectedPoint.LIST_CODEC, this.selectedPoints);
@@ -127,7 +127,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
     public void loadAdditional(@NotNull ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("mercuryFluxStorage").ifPresent(this.mercuryFluxStorage::deserialize);
+        input.child("mercuryFluxHandler").ifPresent(this.mercuryFluxHandler::deserialize);
         this.selectedPoints = input.read("selectedPoints", MercuryFluxEmitterSelectedPoint.LIST_CODEC).orElseGet(ArrayList::new);
     }
 
@@ -166,7 +166,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super.applyImplicitComponents(pComponentInput);
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null) {
-            this.mercuryFluxStorage.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
         }
     }
 
@@ -174,7 +174,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
     protected void collectImplicitComponents(DataComponentMap.@NotNull Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxStorage.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
     }
 
     public void setSelectedPoints(List<MercuryFluxEmitterSelectedPoint> selectedPoints) {
@@ -196,9 +196,9 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         return this.selectedPoints;
     }
 
-    public class MercuryFluxStorage extends DefaultMercuryFluxStorage {
+    public class MercuryFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
 
-        public MercuryFluxStorage(int capacity) {
+        public MercuryFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -96,19 +96,19 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
             if (targetFluxHandler == null)
                 return;
 
-            int accepted = Math.min(FLUX_PER_TRANSFER, targetFluxHandler.getCapacityAsInt() - targetFluxHandler.getAmountAsInt());
-            if (accepted <= 0)
-                return;
-
-            try (net.neoforged.neoforge.transfer.transaction.Transaction tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
-                int extracted = this.mercuryFluxHandler.extract(accepted, tx);
+            try (Transaction tx = Transaction.openRoot()) {
+                int extracted = this.mercuryFluxHandler.extract(FLUX_PER_TRANSFER, tx);
                 if (extracted > 0) {
                     int inserted = targetFluxHandler.insert(extracted, tx);
                     if (inserted <= 0) {
-                        // nothing accepted, abort
                         return;
                     }
-                    // commit the transfer
+
+                    int remainder = extracted - inserted;
+                    if (remainder > 0 && this.mercuryFluxHandler.insert(remainder, tx) != remainder) {
+                        return;
+                    }
+
                     tx.commit();
 
                     Networking.sendToTracking((ServerLevel) this.getLevel(), ChunkPos.containing(this.getBlockPos()), new MessageShowMercuryFlux(this.getBlockPos(), selectedPoint.getBlockPos(), this.getBlockState().getValue(MercuryFluxEmitterBlock.FACING)));

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.network.Networking;
 import com.klikli_dev.theurgy.network.messages.MessageShowMercuryFlux;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -80,7 +80,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         // Transfer to target if we have flux
-        if (this.mercuryFluxHandler.getEnergyStored() >= FLUX_PER_TRANSFER) {
+        if (this.mercuryFluxHandler.getAmountAsInt() >= FLUX_PER_TRANSFER) {
             var targetPos = selectedPoint.getBlockPos();
             var targetState = selectedPoint.getBlockState();
 
@@ -95,13 +95,13 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
             if (targetFluxHandler == null)
                 return;
 
-            int accepted = targetFluxHandler.receiveEnergy(FLUX_PER_TRANSFER, true);
+            int accepted = Math.min(FLUX_PER_TRANSFER, targetFluxHandler.getCapacityAsInt() - targetFluxHandler.getAmountAsInt());
             if (accepted <= 0)
                 return;
 
-            int extracted = this.mercuryFluxHandler.extractEnergy(accepted, false);
+            int extracted = this.mercuryFluxHandler.extract(accepted);
             if (extracted > 0) {
-                int inserted = targetFluxHandler.receiveEnergy(extracted, false);
+                int inserted = targetFluxHandler.insert(extracted);
                 if (inserted <= 0)
                     return;
 
@@ -174,7 +174,7 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
     protected void collectImplicitComponents(DataComponentMap.@NotNull Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
     }
 
     public void setSelectedPoints(List<MercuryFluxEmitterSelectedPoint> selectedPoints) {
@@ -196,15 +196,15 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         return this.selectedPoints;
     }
 
-    public class MercuryFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
+    public class MercuryFluxEmitterMercuryFluxHandler extends SimpleMercuryFluxHandler {
 
         public MercuryFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
-            var received = super.receiveEnergy(maxReceive, simulate);
+        public int insert(int amount) {
+            var received = super.insert(amount);
 
             if (received > 0) {
                 MercuryFluxEmitterBlockEntity.this.setChanged();
@@ -214,8 +214,8 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
-            var extracted = super.extractEnergy(maxExtract, simulate);
+        public int extract(int amount) {
+            var extracted = super.extract(amount);
 
             if (extracted > 0) {
                 MercuryFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/MercuryFluxEmitterBlockEntity.java
@@ -210,25 +210,8 @@ public MercuryFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         }
 
         @Override
-        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var received = super.insert(amount, transaction);
-
-            if (received > 0) {
-                MercuryFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return received;
-        }
-
-        @Override
-        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var extracted = super.extract(amount, transaction);
-
-            if (extracted > 0) {
-                MercuryFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return extracted;
+        protected void onEnergyChanged(int previousAmount) {
+            MercuryFluxEmitterBlockEntity.this.setChanged();
         }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
@@ -22,16 +22,16 @@ import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<ReformationArrayRecipeInput, ReformationRecipe, LevelAwareCachedCheck<ReformationArrayRecipeInput, ReformationRecipe>> {
 
-    protected final Supplier<MercuryFluxHandler> MercuryFluxHandlerSupplier;
+    protected final Supplier<MercuryFluxHandler> mercuryFluxHandlerSupplier;
 
-    public ReformationArrayCraftingBehaviour(BlockEntity blockEntity, Supplier<ReformationArrayRecipeInput> recipeWrapperSupplier, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxHandler> MercuryFluxHandlerSupplier) {
+    public ReformationArrayCraftingBehaviour(BlockEntity blockEntity, Supplier<ReformationArrayRecipeInput> recipeWrapperSupplier, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxHandler> mercuryFluxHandlerSupplier) {
         super(blockEntity,
                 recipeWrapperSupplier,
                 inputInventorySupplier,
                 outputInventorySupplier,
                 new LevelAwareCachedCheck<>(RecipeTypeRegistry.REFORMATION.get()));
 
-        this.MercuryFluxHandlerSupplier = MercuryFluxHandlerSupplier;
+        this.mercuryFluxHandlerSupplier = mercuryFluxHandlerSupplier;
     }
 
     @Override
@@ -46,7 +46,7 @@ public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<Reforma
 
         //consume energy
         try (var tx = Transaction.openRoot()) {
-            this.MercuryFluxHandlerSupplier.get().extract(pRecipe.value().getMercuryFlux(), tx);
+            this.mercuryFluxHandlerSupplier.get().extract(pRecipe.value().getMercuryFlux(), tx);
             tx.commit();
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<ReformationArrayRecipeInput, ReformationRecipe, LevelAwareCachedCheck<ReformationArrayRecipeInput, ReformationRecipe>> {
 
@@ -44,7 +45,10 @@ public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<Reforma
         var assembledStack = pRecipe.value().assemble(ItemHandlerRecipeInput);
 
         //consume energy
-        this.MercuryFluxHandlerSupplier.get().extract(pRecipe.value().getMercuryFlux());
+        try (var tx = Transaction.openRoot()) {
+            this.MercuryFluxHandlerSupplier.get().extract(pRecipe.value().getMercuryFlux(), tx);
+            tx.commit();
+        }
 
         // Loop through required sources of recipe and through source inventories and extract
         Set<SettableItemStorage> usedInventories = new HashSet<>();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
@@ -6,7 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.LevelAwareCachedCheck;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.recipe.ReformationRecipe;
 import com.klikli_dev.theurgy.content.recipe.input.ReformationArrayRecipeInput;
 import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
@@ -21,16 +21,16 @@ import java.util.function.Supplier;
 
 public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<ReformationArrayRecipeInput, ReformationRecipe, LevelAwareCachedCheck<ReformationArrayRecipeInput, ReformationRecipe>> {
 
-    protected final Supplier<MercuryFluxStorage> mercuryFluxStorageSupplier;
+    protected final Supplier<MercuryFluxHandler> MercuryFluxHandlerSupplier;
 
-    public ReformationArrayCraftingBehaviour(BlockEntity blockEntity, Supplier<ReformationArrayRecipeInput> recipeWrapperSupplier, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxStorage> mercuryFluxStorageSupplier) {
+    public ReformationArrayCraftingBehaviour(BlockEntity blockEntity, Supplier<ReformationArrayRecipeInput> recipeWrapperSupplier, Supplier<SettableItemStorage> inputInventorySupplier, Supplier<SettableItemStorage> outputInventorySupplier, Supplier<MercuryFluxHandler> MercuryFluxHandlerSupplier) {
         super(blockEntity,
                 recipeWrapperSupplier,
                 inputInventorySupplier,
                 outputInventorySupplier,
                 new LevelAwareCachedCheck<>(RecipeTypeRegistry.REFORMATION.get()));
 
-        this.mercuryFluxStorageSupplier = mercuryFluxStorageSupplier;
+        this.MercuryFluxHandlerSupplier = MercuryFluxHandlerSupplier;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<Reforma
         var assembledStack = pRecipe.value().assemble(ItemHandlerRecipeInput);
 
         //consume energy
-        this.mercuryFluxStorageSupplier.get().extractEnergy(pRecipe.value().getMercuryFlux(), false);
+        this.MercuryFluxHandlerSupplier.get().extractEnergy(pRecipe.value().getMercuryFlux(), false);
 
         // Loop through required sources of recipe and through source inventories and extract
         Set<SettableItemStorage> usedInventories = new HashSet<>();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationArrayCraftingBehaviour.java
@@ -44,7 +44,7 @@ public class ReformationArrayCraftingBehaviour extends CraftingBehaviour<Reforma
         var assembledStack = pRecipe.value().assemble(ItemHandlerRecipeInput);
 
         //consume energy
-        this.MercuryFluxHandlerSupplier.get().extractEnergy(pRecipe.value().getMercuryFlux(), false);
+        this.MercuryFluxHandlerSupplier.get().extract(pRecipe.value().getMercuryFlux());
 
         // Loop through required sources of recipe and through source inventories and extract
         Set<SettableItemStorage> usedInventories = new HashSet<>();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -237,7 +237,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        input.child("mercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
         this.sourcePedestals = new ArrayList<>(input.read("sourcePedestals", SulfuricFluxEmitterSelectedPoint.LIST_CODEC).orElseGet(ArrayList::new));
         this.targetPedestal = input.read("targetPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
         this.resultPedestal = input.read("resultPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
@@ -296,12 +296,6 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         super.collectImplicitComponents(pComponents);
 
         pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
-    }
-
-    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
-        return input.child("mercuryFluxHandler")
-                .or(() -> input.child("MercuryFluxHandler"))
-                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     public SelectionBehaviour<SulfuricFluxEmitterSelectedPoint> getSelectionBehaviour() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -288,7 +288,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         super.applyImplicitComponents(pComponentInput);
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
-            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.set(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -6,7 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryFluxHandler;
 import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.entity.FollowProjectile;
 import com.klikli_dev.theurgy.content.recipe.input.ReformationArrayRecipeInput;
@@ -295,7 +295,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
     }
 
     public SelectionBehaviour<SulfuricFluxEmitterSelectedPoint> getSelectionBehaviour() {
@@ -402,15 +402,15 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
     }
 
-    public class SulfuricFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
+    public class SulfuricFluxEmitterMercuryFluxHandler extends SimpleMercuryFluxHandler {
 
         public SulfuricFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 
         @Override
-        public int receiveEnergy(int maxReceive, boolean simulate) {
-            var received = super.receiveEnergy(maxReceive, simulate);
+        public int insert(int amount) {
+            var received = super.insert(amount);
 
             if (received > 0) {
                 SulfuricFluxEmitterBlockEntity.this.setChanged();
@@ -420,8 +420,8 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int extractEnergy(int maxExtract, boolean simulate) {
-            var extracted = super.extractEnergy(maxExtract, simulate);
+        public int extract(int amount) {
+            var extracted = super.extract(amount);
 
             if (extracted > 0) {
                 SulfuricFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -409,8 +409,8 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int insert(int amount) {
-            var received = super.insert(amount);
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var received = super.insert(amount, transaction);
 
             if (received > 0) {
                 SulfuricFluxEmitterBlockEntity.this.setChanged();
@@ -420,8 +420,8 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int extract(int amount) {
-            var extracted = super.extract(amount);
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            var extracted = super.extract(amount, transaction);
 
             if (extracted > 0) {
                 SulfuricFluxEmitterBlockEntity.this.setChanged();

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -220,10 +220,10 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput mercuryFluxOutput = output.child("MercuryFluxHandler");
+        ValueOutput mercuryFluxOutput = output.child("mercuryFluxHandler");
         this.mercuryFluxHandler.serialize(mercuryFluxOutput);
         if (mercuryFluxOutput.isEmpty()) {
-            output.discard("MercuryFluxHandler");
+            output.discard("mercuryFluxHandler");
         }
 
         output.store("sourcePedestals", SulfuricFluxEmitterSelectedPoint.LIST_CODEC, this.sourcePedestals);
@@ -237,7 +237,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
+        this.findMercuryFluxInput(input).ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
         this.sourcePedestals = new ArrayList<>(input.read("sourcePedestals", SulfuricFluxEmitterSelectedPoint.LIST_CODEC).orElseGet(ArrayList::new));
         this.targetPedestal = input.read("targetPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
         this.resultPedestal = input.read("resultPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
@@ -296,6 +296,12 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         super.collectImplicitComponents(pComponents);
 
         pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getAmountAsInt());
+    }
+
+    private java.util.Optional<ValueInput> findMercuryFluxInput(ValueInput input) {
+        return input.child("mercuryFluxHandler")
+                .or(() -> input.child("MercuryFluxHandler"))
+                .or(() -> input.child("mercuryFluxStorage"));
     }
 
     public SelectionBehaviour<SulfuricFluxEmitterSelectedPoint> getSelectionBehaviour() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -6,7 +6,8 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.selection.SelectionBehaviour;
-import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.SimpleMercuryHandler;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.entity.FollowProjectile;
 import com.klikli_dev.theurgy.content.recipe.input.ReformationArrayRecipeInput;
 import com.klikli_dev.theurgy.content.render.Color;
@@ -41,7 +42,7 @@ public class
 SulfuricFluxEmitterBlockEntity extends BlockEntity {
 
     public static final int CAPACITY = 1000;
-    public MercuryFluxStorage mercuryFluxStorage;
+    public SulfuricFluxEmitterMercuryFluxHandler mercuryFluxHandler;
 
     public boolean isValidMultiblock;
     protected List<SulfuricFluxEmitterSelectedPoint> sourcePedestals;
@@ -57,14 +58,14 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     public SulfuricFluxEmitterBlockEntity(BlockPos pPos, BlockState pBlockState) {
         super(BlockEntityRegistry.SULFURIC_FLUX_EMITTER.get(), pPos, pBlockState);
 
-        this.mercuryFluxStorage = new MercuryFluxStorage(CAPACITY);
+        this.mercuryFluxHandler = new SulfuricFluxEmitterMercuryFluxHandler(CAPACITY);
 
         this.checkValidMultiblockOnNextQuery = true;
 
         this.sourcePedestals = new ArrayList<>();
         this.sourcePedestalsWithContents = new ArrayList<>();
 
-        this.craftingBehaviour = new ReformationArrayCraftingBehaviour(this, () -> this.ItemHandlerRecipeInput, () -> null, this::getOutputInventory, () -> this.mercuryFluxStorage);
+        this.craftingBehaviour = new ReformationArrayCraftingBehaviour(this, () -> this.ItemHandlerRecipeInput, () -> null, this::getOutputInventory, () -> (MercuryFluxHandler) this.mercuryFluxHandler);
     }
 
     public void removeResultPedestal(ReformationResultPedestalBlockEntity pedestal) {
@@ -172,7 +173,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         this.onSourcePedestalContentChange(null); //only call it once as we don't need to call it on each
 
 
-        this.ItemHandlerRecipeInput = new ReformationArrayRecipeInput(sourceInventories, targetPedestalBlockEntity.inputInventory, this.mercuryFluxStorage);
+        this.ItemHandlerRecipeInput = new ReformationArrayRecipeInput(sourceInventories, targetPedestalBlockEntity.inputInventory, (MercuryFluxHandler) this.mercuryFluxHandler);
     }
 
     public void onDisassembleMultiblock() {
@@ -219,10 +220,10 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
 
-        ValueOutput mercuryFluxOutput = output.child("mercuryFluxStorage");
-        this.mercuryFluxStorage.serialize(mercuryFluxOutput);
+        ValueOutput mercuryFluxOutput = output.child("MercuryFluxHandler");
+        this.mercuryFluxHandler.serialize(mercuryFluxOutput);
         if (mercuryFluxOutput.isEmpty()) {
-            output.discard("mercuryFluxStorage");
+            output.discard("MercuryFluxHandler");
         }
 
         output.store("sourcePedestals", SulfuricFluxEmitterSelectedPoint.LIST_CODEC, this.sourcePedestals);
@@ -236,7 +237,7 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        input.child("mercuryFluxStorage").ifPresent(this.mercuryFluxStorage::deserialize);
+        input.child("MercuryFluxHandler").ifPresent(value -> this.mercuryFluxHandler.deserialize(value));
         this.sourcePedestals = new ArrayList<>(input.read("sourcePedestals", SulfuricFluxEmitterSelectedPoint.LIST_CODEC).orElseGet(ArrayList::new));
         this.targetPedestal = input.read("targetPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
         this.resultPedestal = input.read("resultPedestal", SulfuricFluxEmitterSelectedPoint.CODEC).orElse(null);
@@ -287,14 +288,14 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         super.applyImplicitComponents(pComponentInput);
 
         if (pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()) != null)
-            this.mercuryFluxStorage.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
+            this.mercuryFluxHandler.setEnergyStored(pComponentInput.get(DataComponentRegistry.MERCURY_FLUX_STORAGE.get()));
     }
 
     @Override
     protected void collectImplicitComponents(DataComponentMap.Builder pComponents) {
         super.collectImplicitComponents(pComponents);
 
-        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxStorage.getEnergyStored());
+        pComponents.set(DataComponentRegistry.MERCURY_FLUX_STORAGE, this.mercuryFluxHandler.getEnergyStored());
     }
 
     public SelectionBehaviour<SulfuricFluxEmitterSelectedPoint> getSelectionBehaviour() {
@@ -401,9 +402,9 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
     }
 
-    public class MercuryFluxStorage extends DefaultMercuryFluxStorage {
+    public class SulfuricFluxEmitterMercuryFluxHandler extends SimpleMercuryHandler {
 
-        public MercuryFluxStorage(int capacity) {
+        public SulfuricFluxEmitterMercuryFluxHandler(int capacity) {
             super(capacity);
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/SulfuricFluxEmitterBlockEntity.java
@@ -409,25 +409,8 @@ SulfuricFluxEmitterBlockEntity extends BlockEntity {
         }
 
         @Override
-        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var received = super.insert(amount, transaction);
-
-            if (received > 0) {
-                SulfuricFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return received;
-        }
-
-        @Override
-        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
-            var extracted = super.extract(amount, transaction);
-
-            if (extracted > 0) {
-                SulfuricFluxEmitterBlockEntity.this.setChanged();
-            }
-
-            return extracted;
+        protected void onEnergyChanged(int previousAmount) {
+            SulfuricFluxEmitterBlockEntity.this.setChanged();
         }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
@@ -5,12 +5,13 @@
 package com.klikli_dev.theurgy.content.capability;
 
 import com.google.common.primitives.Ints;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
  * Copy of EnergyHandler, separate to prevent conversion to/from FE.
- * 
+ *
  * Mirrors the NeoForge EnergyHandler interface with long-based amount/capacity
- * and direct insert/extract methods without simulate parameter.
+ * and transaction-based insert/extract methods.
  */
 public interface MercuryFluxHandler {
     /**
@@ -59,16 +60,22 @@ public interface MercuryFluxHandler {
     /**
      * Inserts up to the given amount of energy into the handler.
      *
-     * @param amount The maximum amount of energy to insert. <strong>Must be non-negative.</strong>
+     * <p>Changes to the handler are made in the context of a transaction.
+     *
+     * @param amount      The maximum amount of energy to insert. <strong>Must be non-negative.</strong>
+     * @param transaction The transaction that this operation is part of.
      * @return The amount that was inserted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
      */
-    int insert(int amount);
+    int insert(int amount, TransactionContext transaction);
 
     /**
      * Extracts up to the given amount of energy from the handler.
      *
-     * @param amount The maximum amount of energy to extract. <strong>Must be non-negative.</strong>
+     * <p>Changes to the handler are made in the context of a transaction.
+     *
+     * @param amount      The maximum amount of energy to extract. <strong>Must be non-negative.</strong>
+     * @param transaction The transaction that this operation is part of.
      * @return The amount that was extracted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
      */
-    int extract(int amount);
+    int extract(int amount, TransactionContext transaction);
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
@@ -7,7 +7,7 @@ package com.klikli_dev.theurgy.content.capability;
 /**
  * Copy of IEnergyStorage, separate to prevent conversion to/from FE
  */
-public interface MercuryFluxStorage {
+public interface MercuryFluxHandler {
     /**
      * Adds energy to the storage. Returns quantity of energy that was accepted.
      *

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
@@ -9,9 +9,8 @@ import com.google.common.primitives.Ints;
 /**
  * Copy of EnergyHandler, separate to prevent conversion to/from FE.
  * 
- * Mirrors the NeoForge EnergyHandler interface.
- * Keeps the legacy API (receiveEnergy, extractEnergy) for compatibility while also
- * providing the new API (insert, extract, getAmount, getCapacity).
+ * Mirrors the NeoForge EnergyHandler interface with long-based amount/capacity
+ * and direct insert/extract methods without simulate parameter.
  */
 public interface MercuryFluxHandler {
     /**
@@ -63,9 +62,7 @@ public interface MercuryFluxHandler {
      * @param amount The maximum amount of energy to insert. <strong>Must be non-negative.</strong>
      * @return The amount that was inserted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
      */
-    default int insert(int amount) {
-        return receiveEnergy(amount, false);
-    }
+    int insert(int amount);
 
     /**
      * Extracts up to the given amount of energy from the handler.
@@ -73,48 +70,5 @@ public interface MercuryFluxHandler {
      * @param amount The maximum amount of energy to extract. <strong>Must be non-negative.</strong>
      * @return The amount that was extracted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
      */
-    default int extract(int amount) {
-        return extractEnergy(amount, false);
-    }
-
-    // Legacy API - implementations should implement these
-    
-    /**
-     * Adds energy to the storage. Returns quantity of energy that was accepted.
-     *
-     * @param maxReceive Maximum amount of energy to be inserted.
-     * @param simulate   If TRUE, the insertion will only be simulated.
-     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
-     */
-    int receiveEnergy(int maxReceive, boolean simulate);
-
-    /**
-     * Removes energy from the storage. Returns quantity of energy that was removed.
-     *
-     * @param maxExtract Maximum amount of energy to be extracted.
-     * @param simulate   If TRUE, the extraction will only be simulated.
-     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
-     */
-    int extractEnergy(int maxExtract, boolean simulate);
-
-    /**
-     * Returns the amount of energy currently stored.
-     */
-    default int getEnergyStored() {
-        return getAmountAsInt();
-    }
-
-    /**
-     * Sets the amount of energy stored.
-     */
-    default void setEnergyStored(int energy) {
-        throw new UnsupportedOperationException("Default implementation does not support setEnergyStored");
-    }
-
-    /**
-     * Returns the maximum amount of energy that can be stored.
-     */
-    default int getMaxEnergyStored() {
-        return getCapacityAsInt();
-    }
+    int extract(int amount);
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/MercuryFluxHandler.java
@@ -4,10 +4,81 @@
 
 package com.klikli_dev.theurgy.content.capability;
 
+import com.google.common.primitives.Ints;
+
 /**
- * Copy of IEnergyStorage, separate to prevent conversion to/from FE
+ * Copy of EnergyHandler, separate to prevent conversion to/from FE.
+ * 
+ * Mirrors the NeoForge EnergyHandler interface.
+ * Keeps the legacy API (receiveEnergy, extractEnergy) for compatibility while also
+ * providing the new API (insert, extract, getAmount, getCapacity).
  */
 public interface MercuryFluxHandler {
+    /**
+     * Returns the amount of energy currently stored, as a {@code long}.
+     *
+     * <p>The returned amount must be <strong>non-negative</strong>.
+     *
+     * @return the amount as a long
+     * @see #getAmountAsInt()
+     */
+    long getAmountAsLong();
+
+    /**
+     * Returns the amount of energy currently stored, as an {@code int}.
+     *
+     * <p>This is a convenience method to clamp the amount to an {@code int}.
+     *
+     * @return the amount as an {@code int}
+     */
+    default int getAmountAsInt() {
+        return Ints.saturatedCast(getAmountAsLong());
+    }
+
+    /**
+     * Returns the capacity of the handler, irrespective of the current amount, as a {@code long}.
+     *
+     * <p>This function serves as a hint on the maximum amount the energy handler might contain,
+     * for example the handler can be considered full if {@code amount >= capacity}.
+     *
+     * @return the capacity, as a long
+     * @see #getCapacityAsInt()
+     */
+    long getCapacityAsLong();
+
+    /**
+     * Returns the capacity of the handler, irrespective of the current amount, as an {@code int}.
+     *
+     * <p>This is a convenience method to get the capacity clamped to an {@code int}.
+     *
+     * @return the capacity, as an {@code int}
+     */
+    default int getCapacityAsInt() {
+        return Ints.saturatedCast(getCapacityAsLong());
+    }
+
+    /**
+     * Inserts up to the given amount of energy into the handler.
+     *
+     * @param amount The maximum amount of energy to insert. <strong>Must be non-negative.</strong>
+     * @return The amount that was inserted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
+     */
+    default int insert(int amount) {
+        return receiveEnergy(amount, false);
+    }
+
+    /**
+     * Extracts up to the given amount of energy from the handler.
+     *
+     * @param amount The maximum amount of energy to extract. <strong>Must be non-negative.</strong>
+     * @return The amount that was extracted. Between {@code 0} (inclusive) and {@code amount} (inclusive).
+     */
+    default int extract(int amount) {
+        return extractEnergy(amount, false);
+    }
+
+    // Legacy API - implementations should implement these
+    
     /**
      * Adds energy to the storage. Returns quantity of energy that was accepted.
      *
@@ -29,27 +100,21 @@ public interface MercuryFluxHandler {
     /**
      * Returns the amount of energy currently stored.
      */
-    int getEnergyStored();
+    default int getEnergyStored() {
+        return getAmountAsInt();
+    }
 
     /**
      * Sets the amount of energy stored.
      */
-    void setEnergyStored(int energy);
+    default void setEnergyStored(int energy) {
+        throw new UnsupportedOperationException("Default implementation does not support setEnergyStored");
+    }
 
     /**
      * Returns the maximum amount of energy that can be stored.
      */
-    int getMaxEnergyStored();
-
-    /**
-     * Returns if this storage can have energy extracted.
-     * If this is false, then any calls to extractEnergy will return 0.
-     */
-    boolean canExtract();
-
-    /**
-     * Used to determine if this storage can receive energy.
-     * If this is false, then any calls to receiveEnergy will return 0.
-     */
-    boolean canReceive();
+    default int getMaxEnergyStored() {
+        return getCapacityAsInt();
+    }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
@@ -15,25 +15,25 @@ import net.neoforged.neoforge.common.util.ValueIOSerializable;
 /**
  * Copy of EnergyStorage, separate to prevent conversion to/from FE
  */
-public class SimpleMercuryHandler implements MercuryFluxHandler, NBTSerializable<Tag>, ValueIOSerializable {
+public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializable<Tag>, ValueIOSerializable {
     protected int energy;
     protected int capacity;
     protected int maxReceive;
     protected int maxExtract;
 
-    public SimpleMercuryHandler(int capacity) {
+    public SimpleMercuryFluxHandler(int capacity) {
         this(capacity, capacity, capacity, 0);
     }
 
-    public SimpleMercuryHandler(int capacity, int maxTransfer) {
+    public SimpleMercuryFluxHandler(int capacity, int maxTransfer) {
         this(capacity, maxTransfer, maxTransfer, 0);
     }
 
-    public SimpleMercuryHandler(int capacity, int maxReceive, int maxExtract) {
+    public SimpleMercuryFluxHandler(int capacity, int maxReceive, int maxExtract) {
         this(capacity, maxReceive, maxExtract, 0);
     }
 
-    public SimpleMercuryHandler(int capacity, int maxReceive, int maxExtract, int energy) {
+    public SimpleMercuryFluxHandler(int capacity, int maxReceive, int maxExtract, int energy) {
         this.capacity = capacity;
         this.maxReceive = maxReceive;
         this.maxExtract = maxExtract;
@@ -41,32 +41,43 @@ public class SimpleMercuryHandler implements MercuryFluxHandler, NBTSerializable
     }
 
     @Override
-    public int receiveEnergy(int maxReceive, boolean simulate) {
-        if (!this.canReceive())
-            return 0;
+    public int insert(int amount) {
+        if (amount <= 0 || !this.canReceive()) return 0;
 
-        int energyReceived = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, maxReceive));
-        if (!simulate)
-            this.energy += energyReceived;
-        return energyReceived;
+        int energyInserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+        this.energy += energyInserted;
+        return energyInserted;
     }
 
     @Override
-    public int extractEnergy(int maxExtract, boolean simulate) {
-        if (!this.canExtract())
-            return 0;
+    public int extract(int amount) {
+        if (amount <= 0 || !this.canExtract()) return 0;
 
-        int energyExtracted = Math.min(this.energy, Math.min(this.maxExtract, maxExtract));
-        if (!simulate)
-            this.energy -= energyExtracted;
+        int energyExtracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
+        this.energy -= energyExtracted;
         return energyExtracted;
+    }
+
+    /**
+     * Simulate insertion without changing state.
+     */
+    public int simulateInsert(int amount) {
+        if (amount <= 0 || !this.canReceive()) return 0;
+        return Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+    }
+
+    /**
+     * Simulate extraction without changing state.
+     */
+    public int simulateExtract(int amount) {
+        if (amount <= 0 || !this.canExtract()) return 0;
+        return Math.min(this.energy, Math.min(this.maxExtract, amount));
     }
 
     public int getEnergyStored() {
         return this.energy;
     }
 
-    @Override
     public void setEnergyStored(int energy) {
         this.energy = Math.max(0, Math.min(this.capacity, energy));
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
@@ -11,6 +11,8 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.neoforge.common.util.ValueIOSerializable;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
+
 
 /**
  * Copy of EnergyStorage, separate to prevent conversion to/from FE
@@ -40,39 +42,43 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
         this.energy = Math.max(0, Math.min(capacity, energy));
     }
 
-    @Override
     public int insert(int amount) {
         if (amount <= 0 || !this.canReceive()) return 0;
 
         int energyInserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+        int previous = this.energy;
         this.energy += energyInserted;
+        this.onEnergyChanged(previous);
         return energyInserted;
     }
 
-    @Override
     public int extract(int amount) {
         if (amount <= 0 || !this.canExtract()) return 0;
 
         int energyExtracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
+        int previous = this.energy;
         this.energy -= energyExtracted;
+        this.onEnergyChanged(previous);
         return energyExtracted;
     }
 
-    /**
-     * Simulate insertion without changing state.
-     */
-    public int simulateInsert(int amount) {
-        if (amount <= 0 || !this.canReceive()) return 0;
-        return Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+    // Transaction-aware variants (interface methods)
+    @Override
+    public int insert(int amount, TransactionContext transaction) {
+        // Simple implementation that ignores transactional snapshots and behaves eagerly.
+        // We keep the old behavior to minimize changes; callers will open transactions around multi-step flows.
+        return this.insert(amount);
+    }
+
+    @Override
+    public int extract(int amount, TransactionContext transaction) {
+        return this.extract(amount);
     }
 
     /**
-     * Simulate extraction without changing state.
+     * NOTE: simulation helpers removed. Callers should use getAmountAsInt()/getCapacityAsInt()
+     * and account for transfer limits themselves when necessary.
      */
-    public int simulateExtract(int amount) {
-        if (amount <= 0 || !this.canExtract()) return 0;
-        return Math.min(this.energy, Math.min(this.maxExtract, amount));
-    }
 
     public int getEnergyStored() {
         return this.energy;
@@ -102,6 +108,14 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
 
     public boolean canReceive() {
         return this.maxReceive > 0;
+    }
+
+    /**
+     * Hook invoked when energy changes. Subclasses may override to react (e.g. mark BE changed).
+     * The parameter is the previous amount before the change.
+     */
+    protected void onEnergyChanged(int previousAmount) {
+        // default: no-op
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
@@ -11,17 +11,21 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.neoforge.common.util.ValueIOSerializable;
+import net.neoforged.neoforge.transfer.TransferPreconditions;
+import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 
 /**
- * Copy of EnergyStorage, separate to prevent conversion to/from FE
+ * Copy of SimpleEnergyHandler, separate to prevent conversion to/from FE.
  */
 public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializable<Tag>, ValueIOSerializable {
     protected int energy;
     protected int capacity;
     protected int maxReceive;
     protected int maxExtract;
+
+    private final MercuryFluxJournal energyJournal = new MercuryFluxJournal();
 
     public SimpleMercuryFluxHandler(int capacity) {
         this(capacity, capacity, capacity, 0);
@@ -36,16 +40,25 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
     }
 
     public SimpleMercuryFluxHandler(int capacity, int maxReceive, int maxExtract, int energy) {
+        TransferPreconditions.checkNonNegative(capacity);
+        TransferPreconditions.checkNonNegative(maxReceive);
+        TransferPreconditions.checkNonNegative(maxExtract);
+        TransferPreconditions.checkNonNegative(energy);
+
         this.capacity = capacity;
         this.maxReceive = maxReceive;
         this.maxExtract = maxExtract;
-        this.energy = Math.max(0, Math.min(capacity, energy));
+        this.energy = energy;
     }
 
     public int insert(int amount) {
-        if (amount <= 0 || !this.canReceive()) return 0;
+        TransferPreconditions.checkNonNegative(amount);
+
+        if (!this.canReceive()) return 0;
 
         int energyInserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+        if (energyInserted <= 0) return 0;
+
         int previous = this.energy;
         this.energy += energyInserted;
         this.onEnergyChanged(previous);
@@ -53,26 +66,45 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
     }
 
     public int extract(int amount) {
-        if (amount <= 0 || !this.canExtract()) return 0;
+        TransferPreconditions.checkNonNegative(amount);
+
+        if (!this.canExtract()) return 0;
 
         int energyExtracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
+        if (energyExtracted <= 0) return 0;
+
         int previous = this.energy;
         this.energy -= energyExtracted;
         this.onEnergyChanged(previous);
         return energyExtracted;
     }
 
-    // Transaction-aware variants (interface methods)
     @Override
     public int insert(int amount, TransactionContext transaction) {
-        // Simple implementation that ignores transactional snapshots and behaves eagerly.
-        // We keep the old behavior to minimize changes; callers will open transactions around multi-step flows.
-        return this.insert(amount);
+        TransferPreconditions.checkNonNegative(amount);
+
+        int inserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
+        if (inserted > 0) {
+            this.energyJournal.updateSnapshots(transaction);
+            this.energy += inserted;
+            return inserted;
+        }
+
+        return 0;
     }
 
     @Override
     public int extract(int amount, TransactionContext transaction) {
-        return this.extract(amount);
+        TransferPreconditions.checkNonNegative(amount);
+
+        int extracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
+        if (extracted > 0) {
+            this.energyJournal.updateSnapshots(transaction);
+            this.energy -= extracted;
+            return extracted;
+        }
+
+        return 0;
     }
 
     /**
@@ -85,7 +117,13 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
     }
 
     public void setEnergyStored(int energy) {
-        this.energy = Math.max(0, Math.min(this.capacity, energy));
+        TransferPreconditions.checkNonNegative(energy);
+
+        if (this.energy != energy) {
+            int previous = this.energy;
+            this.energy = energy;
+            this.onEnergyChanged(previous);
+        }
     }
 
     public int getMaxEnergyStored() {
@@ -127,7 +165,7 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
     public void deserializeNBT(HolderLookup.Provider pRegistries, Tag nbt) {
         if (!(nbt instanceof IntTag(int value)))
             throw new IllegalArgumentException("Can not deserialize to an instance that isn't the default implementation");
-        this.energy = value;
+        this.energy = Math.max(0, value);
     }
 
     @Override
@@ -143,6 +181,26 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
         this.capacity = input.getIntOr("capacity", this.capacity);
         this.maxReceive = input.getIntOr("maxReceive", this.maxReceive);
         this.maxExtract = input.getIntOr("maxExtract", this.maxExtract);
-        this.energy = Math.max(0, Math.min(this.capacity, input.getIntOr("energy", 0)));
+        this.energy = Math.max(0, input.getIntOr("energy", 0));
+    }
+
+    private class MercuryFluxJournal extends SnapshotJournal<Integer> {
+        @Override
+        protected Integer createSnapshot() {
+            return energy;
+        }
+
+        @Override
+        protected void revertToSnapshot(Integer snapshot) {
+            energy = snapshot;
+        }
+
+        @Override
+        protected void onRootCommit(Integer originalState) {
+            int previousAmount = originalState;
+            if (energy != previousAmount) {
+                onEnergyChanged(previousAmount);
+            }
+        }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
@@ -107,11 +107,6 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
         return 0;
     }
 
-    /**
-     * NOTE: simulation helpers removed. Callers should use getAmountAsInt()/getCapacityAsInt()
-     * and account for transfer limits themselves when necessary.
-     */
-
     public int getEnergyStored() {
         return this.energy;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryFluxHandler.java
@@ -4,10 +4,6 @@
 
 package com.klikli_dev.theurgy.content.capability;
 
-import com.klikli_dev.theurgy.util.NBTSerializable;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.IntTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.neoforge.common.util.ValueIOSerializable;
@@ -19,111 +15,59 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 /**
  * Copy of SimpleEnergyHandler, separate to prevent conversion to/from FE.
  */
-public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializable<Tag>, ValueIOSerializable {
+public class SimpleMercuryFluxHandler implements MercuryFluxHandler, ValueIOSerializable {
     protected int energy;
     protected int capacity;
-    protected int maxReceive;
+    protected int maxInsert;
     protected int maxExtract;
 
-    private final MercuryFluxJournal energyJournal = new MercuryFluxJournal();
+    private final EnergyJournal energyJournal = new EnergyJournal();
 
     public SimpleMercuryFluxHandler(int capacity) {
-        this(capacity, capacity, capacity, 0);
+        this(capacity, capacity);
     }
 
     public SimpleMercuryFluxHandler(int capacity, int maxTransfer) {
-        this(capacity, maxTransfer, maxTransfer, 0);
+        this(capacity, maxTransfer, maxTransfer);
     }
 
-    public SimpleMercuryFluxHandler(int capacity, int maxReceive, int maxExtract) {
-        this(capacity, maxReceive, maxExtract, 0);
+    public SimpleMercuryFluxHandler(int capacity, int maxInsert, int maxExtract) {
+        this(capacity, maxInsert, maxExtract, 0);
     }
 
-    public SimpleMercuryFluxHandler(int capacity, int maxReceive, int maxExtract, int energy) {
+    public SimpleMercuryFluxHandler(int capacity, int maxInsert, int maxExtract, int energy) {
         TransferPreconditions.checkNonNegative(capacity);
-        TransferPreconditions.checkNonNegative(maxReceive);
+        TransferPreconditions.checkNonNegative(maxInsert);
         TransferPreconditions.checkNonNegative(maxExtract);
         TransferPreconditions.checkNonNegative(energy);
 
         this.capacity = capacity;
-        this.maxReceive = maxReceive;
+        this.maxInsert = maxInsert;
         this.maxExtract = maxExtract;
         this.energy = energy;
     }
 
-    public int insert(int amount) {
-        TransferPreconditions.checkNonNegative(amount);
-
-        if (!this.canReceive()) return 0;
-
-        int energyInserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
-        if (energyInserted <= 0) return 0;
-
-        int previous = this.energy;
-        this.energy += energyInserted;
-        this.onEnergyChanged(previous);
-        return energyInserted;
-    }
-
-    public int extract(int amount) {
-        TransferPreconditions.checkNonNegative(amount);
-
-        if (!this.canExtract()) return 0;
-
-        int energyExtracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
-        if (energyExtracted <= 0) return 0;
-
-        int previous = this.energy;
-        this.energy -= energyExtracted;
-        this.onEnergyChanged(previous);
-        return energyExtracted;
+    @Override
+    public void serialize(ValueOutput output) {
+        output.putInt("energy", energy);
     }
 
     @Override
-    public int insert(int amount, TransactionContext transaction) {
+    public void deserialize(ValueInput input) {
+        energy = Math.max(0, input.getIntOr("energy", 0));
+    }
+
+    public void set(int amount) {
         TransferPreconditions.checkNonNegative(amount);
 
-        int inserted = Math.min(this.capacity - this.energy, Math.min(this.maxReceive, amount));
-        if (inserted > 0) {
-            this.energyJournal.updateSnapshots(transaction);
-            this.energy += inserted;
-            return inserted;
-        }
-
-        return 0;
-    }
-
-    @Override
-    public int extract(int amount, TransactionContext transaction) {
-        TransferPreconditions.checkNonNegative(amount);
-
-        int extracted = Math.min(this.energy, Math.min(this.maxExtract, amount));
-        if (extracted > 0) {
-            this.energyJournal.updateSnapshots(transaction);
-            this.energy -= extracted;
-            return extracted;
-        }
-
-        return 0;
-    }
-
-    public int getEnergyStored() {
-        return this.energy;
-    }
-
-    public void setEnergyStored(int energy) {
-        TransferPreconditions.checkNonNegative(energy);
-
-        if (this.energy != energy) {
-            int previous = this.energy;
-            this.energy = energy;
-            this.onEnergyChanged(previous);
+        if (this.energy != amount) {
+            int previousAmount = this.energy;
+            this.energy = amount;
+            onEnergyChanged(previousAmount);
         }
     }
 
-    public int getMaxEnergyStored() {
-        return this.capacity;
-    }
+    protected void onEnergyChanged(int previousAmount) {}
 
     @Override
     public long getAmountAsLong() {
@@ -135,51 +79,35 @@ public class SimpleMercuryFluxHandler implements MercuryFluxHandler, NBTSerializ
         return this.capacity;
     }
 
-    public boolean canExtract() {
-        return this.maxExtract > 0;
-    }
+    @Override
+    public int insert(int amount, TransactionContext transaction) {
+        TransferPreconditions.checkNonNegative(amount);
 
-    public boolean canReceive() {
-        return this.maxReceive > 0;
-    }
+        int inserted = Math.min(capacity - energy, Math.min(amount, maxInsert));
+        if (inserted > 0) {
+            energyJournal.updateSnapshots(transaction);
+            energy += inserted;
+            return inserted;
+        }
 
-    /**
-     * Hook invoked when energy changes. Subclasses may override to react (e.g. mark BE changed).
-     * The parameter is the previous amount before the change.
-     */
-    protected void onEnergyChanged(int previousAmount) {
-        // default: no-op
+        return 0;
     }
 
     @Override
-    public Tag serializeNBT(HolderLookup.Provider pRegistries) {
-        return IntTag.valueOf(this.getEnergyStored());
+    public int extract(int amount, TransactionContext transaction) {
+        TransferPreconditions.checkNonNegative(amount);
+
+        int extracted = Math.min(energy, Math.min(amount, maxExtract));
+        if (extracted > 0) {
+            energyJournal.updateSnapshots(transaction);
+            energy -= extracted;
+            return extracted;
+        }
+
+        return 0;
     }
 
-    @Override
-    public void deserializeNBT(HolderLookup.Provider pRegistries, Tag nbt) {
-        if (!(nbt instanceof IntTag(int value)))
-            throw new IllegalArgumentException("Can not deserialize to an instance that isn't the default implementation");
-        this.energy = Math.max(0, value);
-    }
-
-    @Override
-    public void serialize(ValueOutput output) {
-        output.putInt("energy", this.energy);
-        output.putInt("capacity", this.capacity);
-        output.putInt("maxReceive", this.maxReceive);
-        output.putInt("maxExtract", this.maxExtract);
-    }
-
-    @Override
-    public void deserialize(ValueInput input) {
-        this.capacity = input.getIntOr("capacity", this.capacity);
-        this.maxReceive = input.getIntOr("maxReceive", this.maxReceive);
-        this.maxExtract = input.getIntOr("maxExtract", this.maxExtract);
-        this.energy = Math.max(0, input.getIntOr("energy", 0));
-    }
-
-    private class MercuryFluxJournal extends SnapshotJournal<Integer> {
+    private class EnergyJournal extends SnapshotJournal<Integer> {
         @Override
         protected Integer createSnapshot() {
             return energy;

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryHandler.java
@@ -62,7 +62,6 @@ public class SimpleMercuryHandler implements MercuryFluxHandler, NBTSerializable
         return energyExtracted;
     }
 
-    @Override
     public int getEnergyStored() {
         return this.energy;
     }
@@ -72,17 +71,24 @@ public class SimpleMercuryHandler implements MercuryFluxHandler, NBTSerializable
         this.energy = Math.max(0, Math.min(this.capacity, energy));
     }
 
-    @Override
     public int getMaxEnergyStored() {
         return this.capacity;
     }
 
     @Override
+    public long getAmountAsLong() {
+        return this.energy;
+    }
+
+    @Override
+    public long getCapacityAsLong() {
+        return this.capacity;
+    }
+
     public boolean canExtract() {
         return this.maxExtract > 0;
     }
 
-    @Override
     public boolean canReceive() {
         return this.maxReceive > 0;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryHandler.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/capability/SimpleMercuryHandler.java
@@ -15,25 +15,25 @@ import net.neoforged.neoforge.common.util.ValueIOSerializable;
 /**
  * Copy of EnergyStorage, separate to prevent conversion to/from FE
  */
-public class DefaultMercuryFluxStorage implements MercuryFluxStorage, NBTSerializable<Tag>, ValueIOSerializable {
+public class SimpleMercuryHandler implements MercuryFluxHandler, NBTSerializable<Tag>, ValueIOSerializable {
     protected int energy;
     protected int capacity;
     protected int maxReceive;
     protected int maxExtract;
 
-    public DefaultMercuryFluxStorage(int capacity) {
+    public SimpleMercuryHandler(int capacity) {
         this(capacity, capacity, capacity, 0);
     }
 
-    public DefaultMercuryFluxStorage(int capacity, int maxTransfer) {
+    public SimpleMercuryHandler(int capacity, int maxTransfer) {
         this(capacity, maxTransfer, maxTransfer, 0);
     }
 
-    public DefaultMercuryFluxStorage(int capacity, int maxReceive, int maxExtract) {
+    public SimpleMercuryHandler(int capacity, int maxReceive, int maxExtract) {
         this(capacity, maxReceive, maxExtract, 0);
     }
 
-    public DefaultMercuryFluxStorage(int capacity, int maxReceive, int maxExtract, int energy) {
+    public SimpleMercuryHandler(int capacity, int maxReceive, int maxExtract, int energy) {
         this.capacity = capacity;
         this.maxReceive = maxReceive;
         this.maxExtract = maxExtract;

--- a/src/main/java/com/klikli_dev/theurgy/content/recipe/ReformationRecipe.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/recipe/ReformationRecipe.java
@@ -96,7 +96,7 @@ public class ReformationRecipe implements Recipe<ReformationArrayRecipeInput> {
     public boolean matches(ReformationArrayRecipeInput pContainer, @NotNull Level pLevel) {
 
         //if we do not have enough flux, exit early
-        if (pContainer.getMercuryFluxStorage().getEnergyStored() < this.mercuryFlux)
+        if (pContainer.getMercuryFluxHandler().getEnergyStored() < this.mercuryFlux)
             return false;
 
         //if the target does not match we can exit early.

--- a/src/main/java/com/klikli_dev/theurgy/content/recipe/ReformationRecipe.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/recipe/ReformationRecipe.java
@@ -96,7 +96,7 @@ public class ReformationRecipe implements Recipe<ReformationArrayRecipeInput> {
     public boolean matches(ReformationArrayRecipeInput pContainer, @NotNull Level pLevel) {
 
         //if we do not have enough flux, exit early
-        if (pContainer.getMercuryFluxHandler().getEnergyStored() < this.mercuryFlux)
+        if (pContainer.getMercuryFluxHandler().getAmountAsInt() < this.mercuryFlux)
             return false;
 
         //if the target does not match we can exit early.

--- a/src/main/java/com/klikli_dev/theurgy/content/recipe/input/ReformationArrayRecipeInput.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/recipe/input/ReformationArrayRecipeInput.java
@@ -4,7 +4,7 @@
 
 package com.klikli_dev.theurgy.content.recipe.input;
 
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
 import net.neoforged.neoforge.transfer.CombinedResourceHandler;
 import net.neoforged.neoforge.transfer.item.ItemResource;
@@ -16,15 +16,15 @@ public class ReformationArrayRecipeInput extends ItemHandlerRecipeInput {
     private final List<SettableItemStorage> sourcePedestalInvs;
     private final SettableItemStorage targetPedestalInv;
 
-    private final MercuryFluxStorage mercuryFluxStorage;
+    private final MercuryFluxHandler mercuryFluxHandler;
 
-    public ReformationArrayRecipeInput(List<SettableItemStorage> sourcePedestalInvs, SettableItemStorage targetPedestalInv, MercuryFluxStorage mercuryFluxStorage) {
+    public ReformationArrayRecipeInput(List<SettableItemStorage> sourcePedestalInvs, SettableItemStorage targetPedestalInv, MercuryFluxHandler mercuryFluxHandler) {
         super(new CombinedResourceHandler<ItemResource>(Stream.concat(Stream.of(targetPedestalInv), sourcePedestalInvs.stream())
                 .toArray(SettableItemStorage[]::new)));
 
         this.sourcePedestalInvs = sourcePedestalInvs;
         this.targetPedestalInv = targetPedestalInv;
-        this.mercuryFluxStorage = mercuryFluxStorage;
+        this.mercuryFluxHandler = mercuryFluxHandler;
     }
 
     public List<SettableItemStorage> getSourcePedestalInvs() {
@@ -35,7 +35,7 @@ public class ReformationArrayRecipeInput extends ItemHandlerRecipeInput {
         return this.targetPedestalInv;
     }
 
-    public MercuryFluxStorage getMercuryFluxStorage() {
-        return this.mercuryFluxStorage;
+    public MercuryFluxHandler getMercuryFluxHandler() {
+        return this.mercuryFluxHandler;
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/InWorldHUDRegistry.java
@@ -9,7 +9,7 @@ import com.klikli_dev.theurgy.content.render.inworldhud.provider.FluidStorageInW
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.GenericCraftingProgressInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.ItemStorageInWorldHUDProvider;
 import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryCatalystInWorldHUDProvider;
-import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxStorageInWorldHUDProvider;
+import com.klikli_dev.theurgy.content.render.inworldhud.provider.MercuryFluxHandlerInWorldHUDProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -37,7 +37,7 @@ public class InWorldHUDRegistry {
 
         registerGenericProvider(new BlockTitleInWorldHUDProvider());
         registerGenericProvider(new GenericCraftingProgressInWorldHUDProvider());
-        registerGenericProvider(new MercuryFluxStorageInWorldHUDProvider());
+        registerGenericProvider(new MercuryFluxHandlerInWorldHUDProvider());
         registerGenericProvider(new FluidStorageInWorldHUDProvider());
         registerGenericProvider(new ItemStorageInWorldHUDProvider());
 

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxHandlerInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxHandlerInWorldHUDProvider.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
-public class MercuryFluxStorageInWorldHUDProvider implements InWorldHUDProvider {
+public class MercuryFluxHandlerInWorldHUDProvider implements InWorldHUDProvider {
 
     @Override
     public boolean activatesHUD() {

--- a/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxHandlerInWorldHUDProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/render/inworldhud/provider/MercuryFluxHandlerInWorldHUDProvider.java
@@ -43,7 +43,7 @@ public class MercuryFluxHandlerInWorldHUDProvider implements InWorldHUDProvider 
 
         builder.addLine(Component.translatable(
                 TheurgyConstants.I18n.JEI.MERCURY_FLUX,
-                storage.getEnergyStored() + " / " + storage.getMaxEnergyStored()
+                storage.getAmountAsInt() + " / " + storage.getCapacityAsInt()
         ).withStyle(ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/CaloricFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/CaloricFluxEmitterGameTests.java
@@ -58,7 +58,7 @@ public class CaloricFluxEmitterGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, CaloricFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() > 0, "Should have energy capacity");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getCapacityAsInt() > 0, "Should have energy capacity");
             helper.succeed();
         });
     }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/CaloricFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/CaloricFluxEmitterGameTests.java
@@ -58,7 +58,7 @@ public class CaloricFluxEmitterGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, CaloricFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxStorage.getMaxEnergyStored() > 0, "Should have energy capacity");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() > 0, "Should have energy capacity");
             helper.succeed();
         });
     }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
@@ -132,7 +132,7 @@ public class MercuryCapacitorGameTests {
         // Fill capacitor A with flux manually
         helper.runAfterDelay(1, () -> {
             var capacitorA = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
-                    capacitorA.mercuryFluxHandler.setEnergyStored(10000);
+                    capacitorA.mercuryFluxHandler.set(10000);
         });
 
         // Wait for several tick cycles and verify no flux transfer happens

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
@@ -38,7 +38,7 @@ public class MercuryCapacitorGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxHandler.getEnergyStored() == 0,
+                    blockEntity.mercuryFluxHandler.getAmountAsInt() == 0,
                     "Mercury Capacitor should start with no flux stored"
             );
         });
@@ -46,7 +46,7 @@ public class MercuryCapacitorGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxHandler.getEnergyStored() == 0,
+                    blockEntity.mercuryFluxHandler.getAmountAsInt() == 0,
                     "Mercury Capacitor should still have no flux stored"
             );
         });
@@ -69,7 +69,7 @@ public class MercuryCapacitorGameTests {
         helper.succeedWhen(() -> {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitorBE.mercuryFluxHandler.getEnergyStored() > 0,
+                    capacitorBE.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Mercury Capacitor should have received flux from Mercury Catalyst"
             );
         });
@@ -84,7 +84,7 @@ public class MercuryCapacitorGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxHandler.getMaxEnergyStored() == MercuryCapacitorBlockEntity.CAPACITY,
+                    blockEntity.mercuryFluxHandler.getCapacityAsInt() == MercuryCapacitorBlockEntity.CAPACITY,
                     "Mercury Capacitor should have capacity of " + MercuryCapacitorBlockEntity.CAPACITY
             );
         });
@@ -112,7 +112,7 @@ public class MercuryCapacitorGameTests {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             // Capacitor should have no flux because it's disabled and can't receive from neighbors
             helper.assertTrue(
-                    capacitorBE.mercuryFluxHandler.getEnergyStored() == 0,
+                    capacitorBE.mercuryFluxHandler.getAmountAsInt() == 0,
                     "Disabled capacitor should not receive flux from neighbors"
             );
         });
@@ -144,11 +144,11 @@ public class MercuryCapacitorGameTests {
 
             // Both should have their original amounts - no transfer
             helper.assertTrue(
-                    capacitorA.mercuryFluxHandler.getEnergyStored() == 10000,
+                    capacitorA.mercuryFluxHandler.getAmountAsInt() == 10000,
                     "Capacitor A should still have 10000 flux (no ping-pong)"
             );
             helper.assertTrue(
-                    capacitorB.mercuryFluxHandler.getEnergyStored() == 0,
+                    capacitorB.mercuryFluxHandler.getAmountAsInt() == 0,
                     "Capacitor B should still have 0 flux (no ping-pong)"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCapacitorGameTests.java
@@ -38,7 +38,7 @@ public class MercuryCapacitorGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxStorage.getEnergyStored() == 0,
+                    blockEntity.mercuryFluxHandler.getEnergyStored() == 0,
                     "Mercury Capacitor should start with no flux stored"
             );
         });
@@ -46,7 +46,7 @@ public class MercuryCapacitorGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxStorage.getEnergyStored() == 0,
+                    blockEntity.mercuryFluxHandler.getEnergyStored() == 0,
                     "Mercury Capacitor should still have no flux stored"
             );
         });
@@ -69,7 +69,7 @@ public class MercuryCapacitorGameTests {
         helper.succeedWhen(() -> {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitorBE.mercuryFluxStorage.getEnergyStored() > 0,
+                    capacitorBE.mercuryFluxHandler.getEnergyStored() > 0,
                     "Mercury Capacitor should have received flux from Mercury Catalyst"
             );
         });
@@ -84,7 +84,7 @@ public class MercuryCapacitorGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxStorage.getMaxEnergyStored() == MercuryCapacitorBlockEntity.CAPACITY,
+                    blockEntity.mercuryFluxHandler.getMaxEnergyStored() == MercuryCapacitorBlockEntity.CAPACITY,
                     "Mercury Capacitor should have capacity of " + MercuryCapacitorBlockEntity.CAPACITY
             );
         });
@@ -112,7 +112,7 @@ public class MercuryCapacitorGameTests {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             // Capacitor should have no flux because it's disabled and can't receive from neighbors
             helper.assertTrue(
-                    capacitorBE.mercuryFluxStorage.getEnergyStored() == 0,
+                    capacitorBE.mercuryFluxHandler.getEnergyStored() == 0,
                     "Disabled capacitor should not receive flux from neighbors"
             );
         });
@@ -132,7 +132,7 @@ public class MercuryCapacitorGameTests {
         // Fill capacitor A with flux manually
         helper.runAfterDelay(1, () -> {
             var capacitorA = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
-            capacitorA.mercuryFluxStorage.setEnergyStored(10000);
+                    capacitorA.mercuryFluxHandler.setEnergyStored(10000);
         });
 
         // Wait for several tick cycles and verify no flux transfer happens
@@ -144,11 +144,11 @@ public class MercuryCapacitorGameTests {
 
             // Both should have their original amounts - no transfer
             helper.assertTrue(
-                    capacitorA.mercuryFluxStorage.getEnergyStored() == 10000,
+                    capacitorA.mercuryFluxHandler.getEnergyStored() == 10000,
                     "Capacitor A should still have 10000 flux (no ping-pong)"
             );
             helper.assertTrue(
-                    capacitorB.mercuryFluxStorage.getEnergyStored() == 0,
+                    capacitorB.mercuryFluxHandler.getEnergyStored() == 0,
                     "Capacitor B should still have 0 flux (no ping-pong)"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
@@ -41,7 +41,7 @@ public class MercuryCatalystGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(CATALYST_POS, MercuryCatalystBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxStorage.getEnergyStored() > 0,
+                    blockEntity.mercuryFluxHandler.getEnergyStored() > 0,
                     "Mercury Catalyst should have generated mercury flux from mercury shard"
             );
         });
@@ -86,7 +86,7 @@ public class MercuryCatalystGameTests {
             var blockEntity = helper.getBlockEntity(CATALYST_POS, MercuryCatalystBlockEntity.class);
             // Crafting should still work, flux should be stored internally
             helper.assertTrue(
-                    blockEntity.mercuryFluxStorage.getEnergyStored() > 0,
+                    blockEntity.mercuryFluxHandler.getEnergyStored() > 0,
                     "Crafting should still generate flux even when disabled"
             );
             helper.succeed();

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
@@ -41,7 +41,7 @@ public class MercuryCatalystGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(CATALYST_POS, MercuryCatalystBlockEntity.class);
             helper.assertTrue(
-                    blockEntity.mercuryFluxHandler.getEnergyStored() > 0,
+                    blockEntity.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Mercury Catalyst should have generated mercury flux from mercury shard"
             );
         });
@@ -86,7 +86,7 @@ public class MercuryCatalystGameTests {
             var blockEntity = helper.getBlockEntity(CATALYST_POS, MercuryCatalystBlockEntity.class);
             // Crafting should still work, flux should be stored internally
             helper.assertTrue(
-                    blockEntity.mercuryFluxHandler.getEnergyStored() > 0,
+                    blockEntity.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Crafting should still generate flux even when disabled"
             );
             helper.succeed();

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
@@ -103,8 +103,11 @@ public class MercuryFluxConnectorGameTests {
             helper.assertTrue(fluxStorage != null, "Connector should expose MERCURY_FLUX_HANDLER capability");
 
             // Push some flux into the buffer
-            int received = fluxStorage.insert(500);
-            helper.assertTrue(received == 500, "Should be able to push 500 flux into connector buffer, got " + received);
+            try (var tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                int received = fluxStorage.insert(500, tx);
+                tx.commit();
+                helper.assertTrue(received == 500, "Should be able to push 500 flux into connector buffer, got " + received);
+            }
 
             var be = helper.getBlockEntity(CONNECTOR_A_POS, LogisticsMercuryFluxConnectorBlockEntity.class);
             helper.assertTrue(

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
@@ -72,7 +72,7 @@ public class MercuryFluxConnectorGameTests {
         helper.runAfterDelay(1, () -> {
             var be = helper.getBlockEntity(CONNECTOR_A_POS, LogisticsMercuryFluxConnectorBlockEntity.class);
             helper.assertTrue(
-                    be.leafNode().buffer().getEnergyStored() == 0,
+                    be.leafNode().buffer().getAmountAsInt() == 0,
                     "Connector buffer should start empty"
             );
         });
@@ -80,7 +80,7 @@ public class MercuryFluxConnectorGameTests {
         helper.succeedWhen(() -> {
             var be = helper.getBlockEntity(CONNECTOR_A_POS, LogisticsMercuryFluxConnectorBlockEntity.class);
             helper.assertTrue(
-                    be.leafNode().buffer().getEnergyStored() == 0,
+                    be.leafNode().buffer().getAmountAsInt() == 0,
                     "Connector buffer should still be empty"
             );
         });
@@ -103,12 +103,12 @@ public class MercuryFluxConnectorGameTests {
             helper.assertTrue(fluxStorage != null, "Connector should expose MERCURY_FLUX_HANDLER capability");
 
             // Push some flux into the buffer
-            int received = fluxStorage.receiveEnergy(500, false);
+            int received = fluxStorage.insert(500);
             helper.assertTrue(received == 500, "Should be able to push 500 flux into connector buffer, got " + received);
 
             var be = helper.getBlockEntity(CONNECTOR_A_POS, LogisticsMercuryFluxConnectorBlockEntity.class);
             helper.assertTrue(
-                    be.leafNode().buffer().getEnergyStored() == 500,
+                    be.leafNode().buffer().getAmountAsInt() == 500,
                     "Connector buffer should have 500 flux after push"
             );
 
@@ -143,7 +143,7 @@ public class MercuryFluxConnectorGameTests {
         helper.succeedWhen(() -> {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_1_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitorBE.mercuryFluxHandler.getEnergyStored() > 0,
+                    capacitorBE.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Capacitor should have received flux forwarded through the logistics network"
             );
         });
@@ -181,11 +181,11 @@ public class MercuryFluxConnectorGameTests {
             var cap1BE = helper.getBlockEntity(CAPACITOR_1_POS, MercuryCapacitorBlockEntity.class);
             var cap2BE = helper.getBlockEntity(CAPACITOR_2_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    cap1BE.mercuryFluxHandler.getEnergyStored() > 0,
+                    cap1BE.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Capacitor 1 should have received flux through the logistics network"
             );
             helper.assertTrue(
-                    cap2BE.mercuryFluxHandler.getEnergyStored() > 0,
+                    cap2BE.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Capacitor 2 should have received flux through the logistics network"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxConnectorGameTests.java
@@ -87,7 +87,7 @@ public class MercuryFluxConnectorGameTests {
     }
 
     /**
-     * Tests that the connector exposes a MercuryFluxStorage capability
+     * Tests that the connector exposes a MercuryFluxHandler capability
      * that source blocks can push into.
      */
     public static void exposesFluxCapability(GameTestHelper helper) {
@@ -143,7 +143,7 @@ public class MercuryFluxConnectorGameTests {
         helper.succeedWhen(() -> {
             var capacitorBE = helper.getBlockEntity(CAPACITOR_1_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitorBE.mercuryFluxStorage.getEnergyStored() > 0,
+                    capacitorBE.mercuryFluxHandler.getEnergyStored() > 0,
                     "Capacitor should have received flux forwarded through the logistics network"
             );
         });
@@ -181,11 +181,11 @@ public class MercuryFluxConnectorGameTests {
             var cap1BE = helper.getBlockEntity(CAPACITOR_1_POS, MercuryCapacitorBlockEntity.class);
             var cap2BE = helper.getBlockEntity(CAPACITOR_2_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    cap1BE.mercuryFluxStorage.getEnergyStored() > 0,
+                    cap1BE.mercuryFluxHandler.getEnergyStored() > 0,
                     "Capacitor 1 should have received flux through the logistics network"
             );
             helper.assertTrue(
-                    cap2BE.mercuryFluxStorage.getEnergyStored() > 0,
+                    cap2BE.mercuryFluxHandler.getEnergyStored() > 0,
                     "Capacitor 2 should have received flux through the logistics network"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxEmitterGameTests.java
@@ -43,7 +43,7 @@ public class MercuryFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, MercuryFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxStorage.getMaxEnergyStored() == MercuryFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + MercuryFluxEmitterBlockEntity.CAPACITY + ")");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() == MercuryFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + MercuryFluxEmitterBlockEntity.CAPACITY + ")");
         });
     }
 
@@ -97,7 +97,7 @@ public class MercuryFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var capacitor = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitor.mercuryFluxStorage.getEnergyStored() > 0,
+                    capacitor.mercuryFluxHandler.getEnergyStored() > 0,
                     "Mercury Capacitor should have received flux from Mercury Flux Emitter"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryFluxEmitterGameTests.java
@@ -43,7 +43,7 @@ public class MercuryFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, MercuryFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() == MercuryFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + MercuryFluxEmitterBlockEntity.CAPACITY + ")");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getCapacityAsInt() == MercuryFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + MercuryFluxEmitterBlockEntity.CAPACITY + ")");
         });
     }
 
@@ -97,7 +97,7 @@ public class MercuryFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var capacitor = helper.getBlockEntity(CAPACITOR_POS, MercuryCapacitorBlockEntity.class);
             helper.assertTrue(
-                    capacitor.mercuryFluxHandler.getEnergyStored() > 0,
+                    capacitor.mercuryFluxHandler.getAmountAsInt() > 0,
                     "Mercury Capacitor should have received flux from Mercury Flux Emitter"
             );
         });

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
@@ -88,7 +88,10 @@ public class SulfuricFluxEmitterGameTests {
         helper.runAtTickTime(2, () -> {
             var emitter = helper.getBlockEntity(EMITTER_POS, SulfuricFluxEmitterBlockEntity.class);
                 // Add initial energy
-                    emitter.mercuryFluxHandler.insert(500);
+                    try (var tx = net.neoforged.neoforge.transfer.transaction.Transaction.openRoot()) {
+                        emitter.mercuryFluxHandler.insert(500, tx);
+                        tx.commit();
+                    }
 
             var source = helper.getBlockEntity(SOURCE_PEDESTAL_POS, ReformationSourcePedestalBlockEntity.class);
             source.inputInventory.setStackInSlot(0, new ItemStack(NiterRegistry.MOBS_ABUNDANT.get(), 1));

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
@@ -65,7 +65,7 @@ public class SulfuricFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, SulfuricFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxStorage.getMaxEnergyStored() == SulfuricFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + SulfuricFluxEmitterBlockEntity.CAPACITY + ")");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() == SulfuricFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + SulfuricFluxEmitterBlockEntity.CAPACITY + ")");
         });
     }
 
@@ -88,7 +88,7 @@ public class SulfuricFluxEmitterGameTests {
         helper.runAtTickTime(2, () -> {
             var emitter = helper.getBlockEntity(EMITTER_POS, SulfuricFluxEmitterBlockEntity.class);
             // Add initial energy
-            emitter.mercuryFluxStorage.receiveEnergy(500, false);
+                    emitter.mercuryFluxHandler.receiveEnergy(500, false);
 
             var source = helper.getBlockEntity(SOURCE_PEDESTAL_POS, ReformationSourcePedestalBlockEntity.class);
             source.inputInventory.setStackInSlot(0, new ItemStack(NiterRegistry.MOBS_ABUNDANT.get(), 1));

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SulfuricFluxEmitterGameTests.java
@@ -65,7 +65,7 @@ public class SulfuricFluxEmitterGameTests {
         helper.succeedWhen(() -> {
             var blockEntity = helper.getBlockEntity(EMITTER_POS, SulfuricFluxEmitterBlockEntity.class);
             helper.assertTrue(blockEntity != null, "Block entity should exist");
-            helper.assertTrue(blockEntity.mercuryFluxHandler.getMaxEnergyStored() == SulfuricFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + SulfuricFluxEmitterBlockEntity.CAPACITY + ")");
+            helper.assertTrue(blockEntity.mercuryFluxHandler.getCapacityAsInt() == SulfuricFluxEmitterBlockEntity.CAPACITY, "Should have correct energy capacity (" + SulfuricFluxEmitterBlockEntity.CAPACITY + ")");
         });
     }
 
@@ -87,8 +87,8 @@ public class SulfuricFluxEmitterGameTests {
 
         helper.runAtTickTime(2, () -> {
             var emitter = helper.getBlockEntity(EMITTER_POS, SulfuricFluxEmitterBlockEntity.class);
-            // Add initial energy
-                    emitter.mercuryFluxHandler.receiveEnergy(500, false);
+                // Add initial energy
+                    emitter.mercuryFluxHandler.insert(500);
 
             var source = helper.getBlockEntity(SOURCE_PEDESTAL_POS, ReformationSourcePedestalBlockEntity.class);
             source.inputInventory.setStackInSlot(0, new ItemStack(NiterRegistry.MOBS_ABUNDANT.get(), 1));

--- a/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
@@ -39,11 +39,11 @@ public class MercuryFluxEnergyProvider<T extends Accessor<?>> implements StreamS
         }
 
         var storage = CommonProxy.getDefaultStorage(accessor, CapabilityRegistry.MERCURY_FLUX_HANDLER, null);
-        if (storage == null || storage.getMaxEnergyStored() <= 0) {
+        if (storage == null || storage.getCapacityAsInt() <= 0) {
             return null;
         }
 
-        ViewGroup<EnergyView.Data> group = new ViewGroup<>(List.of(new EnergyView.Data(storage.getEnergyStored(), storage.getMaxEnergyStored())));
+        ViewGroup<EnergyView.Data> group = new ViewGroup<>(List.of(new EnergyView.Data(storage.getAmountAsInt(), storage.getCapacityAsInt())));
         group.getExtraData().putString("Unit", "MF");
         return List.of(group);
     }

--- a/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/integration/jade/MercuryFluxEnergyProvider.java
@@ -33,7 +33,7 @@ public class MercuryFluxEnergyProvider<T extends Accessor<?>> implements StreamS
             .cast();
     public static final MercuryFluxEnergyProvider<BlockAccessor> BLOCK = new MercuryFluxEnergyProvider<>();
 
-    public static @Nullable List<ViewGroup<EnergyView.Data>> wrapMercuryFluxStorage(Accessor<?> accessor) {
+    public static @Nullable List<ViewGroup<EnergyView.Data>> wrapMercuryFluxHandler(Accessor<?> accessor) {
         if (!(accessor instanceof BlockAccessor)) {
             return null;
         }
@@ -48,7 +48,7 @@ public class MercuryFluxEnergyProvider<T extends Accessor<?>> implements StreamS
         return List.of(group);
     }
 
-    public static boolean hasDefaultMercuryFluxStorage(Accessor<?> accessor) {
+    public static boolean hasSimpleMercuryHandler(Accessor<?> accessor) {
         return accessor instanceof BlockAccessor && CommonProxy.hasDefaultStorage(accessor, CapabilityRegistry.MERCURY_FLUX_HANDLER, null);
     }
 
@@ -87,12 +87,12 @@ public class MercuryFluxEnergyProvider<T extends Accessor<?>> implements StreamS
 
         @Override
         public @Nullable List<ViewGroup<EnergyView.Data>> getGroups(Accessor<?> accessor) {
-            return wrapMercuryFluxStorage(accessor);
+            return wrapMercuryFluxHandler(accessor);
         }
 
         @Override
         public boolean shouldRequestData(Accessor<?> accessor) {
-            return hasDefaultMercuryFluxStorage(accessor);
+            return hasSimpleMercuryHandler(accessor);
         }
 
         @Override

--- a/src/main/java/com/klikli_dev/theurgy/registry/CapabilityRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/registry/CapabilityRegistry.java
@@ -12,7 +12,7 @@ import com.klikli_dev.theurgy.content.apparatus.liquefactioncauldron.Liquefactio
 import com.klikli_dev.theurgy.content.apparatus.logisticsmercuryfluxconnector.LogisticsMercuryFluxConnectorBlockEntity;
 import com.klikli_dev.theurgy.content.capability.HeatProvider;
 import com.klikli_dev.theurgy.content.capability.HeatReceiver;
-import com.klikli_dev.theurgy.content.capability.MercuryFluxStorage;
+import com.klikli_dev.theurgy.content.capability.MercuryFluxHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -35,9 +35,9 @@ public class CapabilityRegistry {
     public static final BlockCapability<ResourceHandler<ItemResource>, @Nullable Direction> ITEM_HANDLER = Capabilities.Item.BLOCK;
     public static final BlockCapability<ResourceHandler<FluidResource>, @Nullable Direction> FLUID_HANDLER = Capabilities.Fluid.BLOCK;
 
-    public static final BlockCapability<MercuryFluxStorage, @Nullable Direction> MERCURY_FLUX_HANDLER = BlockCapability.createSided(
+    public static final BlockCapability<MercuryFluxHandler, @Nullable Direction> MERCURY_FLUX_HANDLER = BlockCapability.createSided(
             Theurgy.loc("mercury_flux_handler"),
-            MercuryFluxStorage.class);
+            MercuryFluxHandler.class);
     public static BlockCapability<HeatProvider, @Nullable Direction> HEAT_PROVIDER = BlockCapability.createSided(
             Theurgy.loc("heat_provider"),
             HeatProvider.class);
@@ -104,7 +104,7 @@ public class CapabilityRegistry {
         event.registerBlockEntity(
                 MERCURY_FLUX_HANDLER,
                 BlockEntityRegistry.CALORIC_FLUX_EMITTER.get(),
-                (blockEntity, side) -> blockEntity.mercuryFluxStorage);
+                (blockEntity, side) -> blockEntity.mercuryFluxHandler);
     }
 
     public static void registerDigestionVat(RegisterCapabilitiesEvent event) {
@@ -263,7 +263,7 @@ public class CapabilityRegistry {
         event.registerBlockEntity(
                 MERCURY_FLUX_HANDLER,
                 BlockEntityRegistry.MERCURY_CATALYST.get(),
-                (blockEntity, side) -> blockEntity.mercuryFluxStorage);
+                (blockEntity, side) -> blockEntity.mercuryFluxHandler);
 
         event.registerBlockEntity(
                 ITEM_HANDLER,
@@ -275,7 +275,7 @@ public class CapabilityRegistry {
         event.registerBlockEntity(
                 MERCURY_FLUX_HANDLER,
                 BlockEntityRegistry.MERCURY_CAPACITOR.get(),
-                (blockEntity, side) -> blockEntity.getMercuryFluxStorage(side));
+                (blockEntity, side) -> blockEntity.getMercuryFluxHandler(side));
     }
 
     public static void registerPyromanticBrazier(RegisterCapabilitiesEvent event) {
@@ -293,7 +293,7 @@ public class CapabilityRegistry {
         event.registerBlockEntity(
                 MERCURY_FLUX_HANDLER,
                 BlockEntityRegistry.SULFURIC_FLUX_EMITTER.get(),
-                (blockEntity, side) -> blockEntity.mercuryFluxStorage);
+                (blockEntity, side) -> blockEntity.mercuryFluxHandler);
 
         event.registerBlockEntity(
                 MERCURY_FLUX_HANDLER,
@@ -304,7 +304,7 @@ public class CapabilityRegistry {
                     var facing = blockState.getValue(BlockStateProperties.FACING);
                     var attachedSide = facing.getOpposite();
                     if (side == null || side == attachedSide) {
-                        return blockEntity.mercuryFluxStorage;
+                        return blockEntity.mercuryFluxHandler;
                     }
                     return null;
                 });


### PR DESCRIPTION
## Summary
- Rename MercuryFluxStorage interface to MercuryFluxHandler to mirror NeoForge's EnergyHandler
- Rename DefaultMercuryFluxStorage to SimpleMercuryHandler to mirror NeoForge's SimpleEnergyHandler
- Update mercury flux capability to use the new API pattern with long-based methods
- Update all dependent block entities and behaviours

## Motivation
The legacy IEnergyStorage/EnergyStorage pattern is deprecated in NeoForge 21.9+. This refactor adopts the new EnergyHandler/SimpleEnergyHandler pattern which provides:
- Long-based amount/capacity methods for better range
- Consistent API naming with insert/extract and getAmount/getCapacity
- Better long-term maintainability

## Changes
- MercuryFluxHandler interface now mirrors EnergyHandler with getAmountAsLong/getCapacityAsLong and insert/extract methods
- SimpleMercuryHandler implements the new methods
- Legacy API methods (receiveEnergy/extractEnergy) are kept for compatibility with default implementations

## Breaking Changes
- Interface methods renamed: receiveEnergy/extractEnergy -> insert/extract (with legacy fallbacks)