### PR TITLE
fix: prevent apparatus rejected placement dupes

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlock.java
@@ -60,9 +60,10 @@ public class PyromanticBrazierBlock extends Block implements EntityBlock {
                     return InteractionResult.SUCCESS;
                 }
             } else {
+                int countBefore = stackInHand.getCount();
                 var remainder = blockEntity.inventory.insertItem(0, stackInHand, false);
-                pPlayer.setItemInHand(pHand, remainder);
-                if (remainder.getCount() != stackInHand.getCount()) {
+                if (remainder.getCount() != countBefore) {
+                    pPlayer.setItemInHand(pHand, remainder);
                     return InteractionResult.SUCCESS;
                 }
                 return InteractionResult.PASS;

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/DynamicOneOutputSlotItemHandlerBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/DynamicOneOutputSlotItemHandlerBehaviour.java
@@ -65,9 +65,10 @@ public class DynamicOneOutputSlotItemHandlerBehaviour implements ItemHandlerBeha
         } else {
             for (int inputSlot = 0; inputSlot <= maxInputSlot; inputSlot++) {
                 //if we have an item in hand, try to insert
+                int countBefore = stackInHand.getCount();
                 var remainder = ItemStorageHelper.insertItem(blockItemHandler, inputSlot, stackInHand, false);
-                pPlayer.setItemInHand(pHand, remainder);
-                if (remainder.getCount() != stackInHand.getCount()) {
+                if (remainder.getCount() != countBefore) {
+                    pPlayer.setItemInHand(pHand, remainder);
                     return InteractionResult.SUCCESS;
                 }
             }

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/OneSlotItemHandlerBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/OneSlotItemHandlerBehaviour.java
@@ -44,9 +44,10 @@ public class OneSlotItemHandlerBehaviour implements ItemHandlerBehaviour {
             }
         } else {
             //if we have an item in hand, try to insert
+            int countBefore = stackInHand.getCount();
             var remainder = ItemStorageHelper.insertItem(blockItemHandler, SLOT, stackInHand, false);
-            pPlayer.setItemInHand(pHand, remainder);
-            if (remainder.getCount() != stackInHand.getCount()) {
+            if (remainder.getCount() != countBefore) {
+                pPlayer.setItemInHand(pHand, remainder);
                 return InteractionResult.SUCCESS;
             }
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/TwoSlotItemHandlerBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/itemhandler/TwoSlotItemHandlerBehaviour.java
@@ -52,9 +52,10 @@ public class TwoSlotItemHandlerBehaviour implements ItemHandlerBehaviour {
             }
         } else {
             //if we have an item in hand, try to insert
+            int countBefore = stackInHand.getCount();
             var remainder = ItemStorageHelper.insertItem(blockItemHandler, INPUT_SLOT, stackInHand, false);
-            pPlayer.setItemInHand(pHand, remainder);
-            if (remainder.getCount() != stackInHand.getCount()) {
+            if (remainder.getCount() != countBefore) {
+                pPlayer.setItemInHand(pHand, remainder);
                 return InteractionResult.SUCCESS;
             }
         }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
@@ -34,6 +34,9 @@ public class GameTestRegistry {
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> MERCURY_SHARD_IS_CONSUMED =
             TEST_FUNCTIONS.register("mercury_catalyst_shard_is_consumed", () -> MercuryCatalystGameTests::mercuryShardIsConsumed);
 
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> MERCURY_CATALYST_REJECTED_PLACEABLE_DONT_DUPLICATE =
+            TEST_FUNCTIONS.register("mercury_catalyst_rejected_placeable_dont_duplicate", () -> MercuryCatalystGameTests::rejectedPlaceableBlockDoesNotDuplicate);
+
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> DISABLED_CATALYST_STILL_GENERATES_FLUX =
             TEST_FUNCTIONS.register("mercury_catalyst_disabled_still_generates_flux", () -> MercuryCatalystGameTests::disabledCatalystStillGeneratesFlux);
 
@@ -176,6 +179,9 @@ public class GameTestRegistry {
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_REMOVE_FUEL =
             TEST_FUNCTIONS.register("pyromantic_brazier_remove_fuel", () -> PyromanticBrazierGameTests::removeFuelViaEmptyHand);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_REJECTED_PLACEABLE_DONT_DUPLICATE =
+            TEST_FUNCTIONS.register("pyromantic_brazier_rejected_placeable_dont_duplicate", () -> PyromanticBrazierGameTests::rejectedPlaceableBlockDoesNotDuplicate);
 
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_DROPS_ITEMS_WHEN_BROKEN =
             TEST_FUNCTIONS.register("pyromantic_brazier_drops_items_when_broken", () -> PyromanticBrazierGameTests::dropsItemsWhenBroken);
@@ -485,6 +491,7 @@ public class GameTestRegistry {
         registerTest(event, PLACEMENT_AND_DEFAULT_STATE, environment, structure, 40, 0);
         registerTest(event, MERCURY_SHARD_GENERATES_FLUX, environment, structure, 200, 0);
         registerTest(event, MERCURY_SHARD_IS_CONSUMED, environment, structure, 200, 0);
+        registerTest(event, MERCURY_CATALYST_REJECTED_PLACEABLE_DONT_DUPLICATE, environment, structure, 40, 0);
         registerTest(event, DISABLED_CATALYST_STILL_GENERATES_FLUX, environment, structure, 100, 0);
     }
 
@@ -552,6 +559,7 @@ public class GameTestRegistry {
         registerTest(event, BRAZIER_HEAT_DISTILLER, environment, structure, 100, 0);
         registerTest(event, BRAZIER_STOPS_HEAT_NO_FUEL, environment, structure, 300, 0);
         registerTest(event, BRAZIER_REMOVE_FUEL, environment, structure, 40, 0);
+        registerTest(event, BRAZIER_REJECTED_PLACEABLE_DONT_DUPLICATE, environment, structure, 40, 0);
         registerTest(event, BRAZIER_DROPS_ITEMS_WHEN_BROKEN, environment, structure, 40, 0);
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/MercuryCatalystGameTests.java
@@ -8,13 +8,21 @@ import com.klikli_dev.theurgy.content.apparatus.mercurycatalyst.MercuryCatalystB
 import com.klikli_dev.theurgy.registry.BlockRegistry;
 import com.klikli_dev.theurgy.registry.ItemRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
 
 public class MercuryCatalystGameTests {
 
     private static final BlockPos CATALYST_POS = new BlockPos(2, 1, 2);
+    private static final BlockPos ABOVE_CATALYST_POS = CATALYST_POS.above();
 
     /**
      * Tests that a Mercury Catalyst block can be placed and has the correct default state (enabled = true).
@@ -67,6 +75,26 @@ public class MercuryCatalystGameTests {
         });
     }
 
+    public static void rejectedPlaceableBlockDoesNotDuplicate(GameTestHelper helper) {
+        helper.setBlock(CATALYST_POS, BlockRegistry.MERCURY_CATALYST.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(CATALYST_POS, MercuryCatalystBlockEntity.class);
+            var player = helper.makeMockPlayer(GameType.SURVIVAL);
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIRT, 1));
+
+            helper.useBlock(CATALYST_POS, player, centeredHitResult(helper, CATALYST_POS));
+            helper.assertTrue(player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty(), "Placed block should be consumed on first click");
+            helper.assertBlockPresent(Blocks.DIRT, ABOVE_CATALYST_POS);
+            helper.assertTrue(blockEntity.inventory.getStackInSlot(0).isEmpty(), "Catalyst should not store rejected placeable blocks");
+
+            helper.useBlock(CATALYST_POS, player, centeredHitResult(helper, CATALYST_POS));
+            helper.assertTrue(player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty(), "Second click should not recreate the consumed block");
+            helper.assertBlockPresent(Blocks.DIRT, ABOVE_CATALYST_POS);
+            helper.succeed();
+        });
+    }
+
     /**
      * Tests that the Mercury Catalyst still generates flux internally when disabled (e.g. by redstone),
      * even though it does not push it to neighbors.
@@ -91,5 +119,9 @@ public class MercuryCatalystGameTests {
             );
             helper.succeed();
         });
+    }
+
+    private static BlockHitResult centeredHitResult(GameTestHelper helper, BlockPos pos) {
+        return new BlockHitResult(Vec3.atCenterOf(helper.absolutePos(pos)), Direction.UP, helper.absolutePos(pos), false);
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -10,12 +10,15 @@ import com.klikli_dev.theurgy.registry.CapabilityRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
-import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
 
 public class PyromanticBrazierGameTests {
 
@@ -148,6 +151,26 @@ public class PyromanticBrazierGameTests {
         });
     }
 
+    public static void rejectedPlaceableBlockDoesNotDuplicate(GameTestHelper helper) {
+        helper.setBlock(BRAZIER_POS, BlockRegistry.PYROMANTIC_BRAZIER.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            var player = helper.makeMockPlayer(GameType.SURVIVAL);
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIRT, 1));
+
+            helper.useBlock(BRAZIER_POS, player, centeredHitResult(helper, BRAZIER_POS));
+            helper.assertTrue(player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty(), "Placed block should be consumed on first click");
+            helper.assertBlockPresent(Blocks.DIRT, ABOVE_BRAZIER_POS);
+            helper.assertTrue(blockEntity.inventory.getStackInSlot(0).isEmpty(), "Brazier should not accept rejected blocks as fuel");
+
+            helper.useBlock(BRAZIER_POS, player, centeredHitResult(helper, BRAZIER_POS));
+            helper.assertTrue(player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty(), "Second click should not recreate the consumed block");
+            helper.assertBlockPresent(Blocks.DIRT, ABOVE_BRAZIER_POS);
+            helper.succeed();
+        });
+    }
+
     /**
      * Tests that fuel items are dropped as entities when the brazier is broken.
      */
@@ -167,6 +190,10 @@ public class PyromanticBrazierGameTests {
             // Verify exact count of coal items dropped
             helper.assertItemEntityCountIs(Items.COAL, BRAZIER_POS, 2.0, 3);
         });
+    }
+
+    private static BlockHitResult centeredHitResult(GameTestHelper helper, BlockPos pos) {
+        return new BlockHitResult(Vec3.atCenterOf(helper.absolutePos(pos)), Direction.UP, helper.absolutePos(pos), false);
     }
 
     // --- Heat Provision ---

--- a/src/main/java/com/klikli_dev/theurgy/gametest/ReformationPedestalGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/ReformationPedestalGameTests.java
@@ -99,4 +99,5 @@ public class ReformationPedestalGameTests {
             helper.succeed();
         });
     }
+
 }


### PR DESCRIPTION
## Summary
- avoid mutating the player's held stack when apparatus item insertion rejects the interaction and returns PASS
- add GameTest coverage for brazier and mercury catalyst rejected placeable-block interactions
- fixes https://github.com/AllTheMods/ATM-11/issues/10

## Validation
- ./gradlew.bat compileJava runGameTestServer