### PR TITLE
fix: restore filter slot interactions

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/filter/attribute/StandardAttributes.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/filter/attribute/StandardAttributes.java
@@ -5,11 +5,11 @@
 
 package com.klikli_dev.theurgy.content.behaviour.filter.attribute;
 
+import com.klikli_dev.theurgy.recipe.TheurgyRecipeManager;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
@@ -39,7 +39,7 @@ public enum StandardAttributes implements ItemAttribute {
     BADLY_DAMAGED(s -> s.isDamaged() && (float) s.getDamageValue() / s.getMaxDamage() > 3 / 4f),
     NOT_STACKABLE(((Predicate<ItemStack>) ItemStack::isStackable).negate()),
     EQUIPABLE(s -> s.has(DataComponents.EQUIPPABLE)),
-    FURNACE_FUEL(s -> s.getBurnTime(RecipeType.SMELTING, null) > 0),
+    FURNACE_FUEL((s, level) -> level != null && s.getBurnTime(RecipeType.SMELTING, level.fuelValues()) > 0),
     SMELTABLE((s, w) -> testRecipe(s, w, RecipeType.SMELTING)),
     SMOKABLE((s, w) -> testRecipe(s, w, RecipeType.SMOKING)),
     BLASTABLE((s, w) -> testRecipe(s, w, RecipeType.BLASTING)),
@@ -58,7 +58,7 @@ public enum StandardAttributes implements ItemAttribute {
 
     private static boolean testRecipe(ItemStack s, Level level, RecipeType<? extends Recipe<SingleRecipeInput>> type) {
         var input = new SingleRecipeInput(s);
-        return ((ServerLevel) level).getServer().getRecipeManager()
+        return TheurgyRecipeManager.get()
                 .getRecipeFor(type, input, level)
                 .isPresent();
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
@@ -4,6 +4,7 @@
 
 package com.klikli_dev.theurgy.content.gui.menu;
 
+import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -11,12 +12,14 @@ import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.items.ComponentItemHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
+import net.neoforged.neoforge.transfer.item.ItemUtil;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearableMenu {
 
-    public ComponentItemHandler ghostInventory;
+    public SettableItemStorage ghostInventory;
 
     protected GhostItemMenu(MenuType<?> type, int id, Inventory inv, RegistryFriendlyByteBuf extraData) {
         super(type, id, inv, extraData);
@@ -26,7 +29,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
         super(type, id, inv, contentHolder);
     }
 
-    protected abstract ComponentItemHandler createGhostInventory();
+    protected abstract SettableItemStorage createGhostInventory();
 
     protected abstract boolean allowRepeats();
 
@@ -37,8 +40,8 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
 
     @Override
     public void clearContents() {
-        for (int i = 0; i < this.ghostInventory.getSlots(); i++)
-            this.ghostInventory.setStackInSlot(i, ItemStack.EMPTY);
+        for (int i = 0; i < this.ghostInventory.size(); i++)
+            this.ghostInventory.set(i, ItemResource.of(ItemStack.EMPTY), 0);
     }
 
     @Override
@@ -64,7 +67,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
         int slot = slotId - 36;
         if (clickTypeIn == ContainerInput.CLONE) {
             if (player.isCreative() && held.isEmpty()) {
-                ItemStack stackInSlot = this.ghostInventory.getStackInSlot(slot).copy();
+                ItemStack stackInSlot = ItemUtil.getStack(this.ghostInventory, slot).copy();
                 stackInSlot.setCount(stackInSlot.getMaxStackSize());
                 this.setCarried(stackInSlot);
                 return;
@@ -79,7 +82,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
             insert = held.copy();
             insert.setCount(1);
         }
-        this.ghostInventory.setStackInSlot(slot, insert);
+        this.ghostInventory.set(slot, ItemResource.of(insert), insert.isEmpty() ? 0 : 1);
         this.getSlot(slotId).setChanged();
     }
 
@@ -87,20 +90,20 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
     public @NotNull ItemStack quickMoveStack(@NotNull Player playerIn, int index) {
         if (index < 36) {
             ItemStack stackToInsert = this.playerInventory.getItem(index);
-            for (int i = 0; i < this.ghostInventory.getSlots(); i++) {
-                ItemStack stack = this.ghostInventory.getStackInSlot(i);
+            for (int i = 0; i < this.ghostInventory.size(); i++) {
+                ItemStack stack = ItemUtil.getStack(this.ghostInventory, i);
                 if (!this.allowRepeats() && ItemStack.isSameItemSameComponents(stack, stackToInsert))
                     break;
                 if (stack.isEmpty()) {
                     ItemStack copy = stackToInsert.copy();
                     copy.setCount(1);
-                    this.ghostInventory.setStackInSlot(i, copy);
+                    this.ghostInventory.set(i, ItemResource.of(copy), 1);
                     this.getSlot(i + 36).setChanged();
                     break;
                 }
             }
         } else {
-            this.ghostInventory.setStackInSlot(index - 36, ItemStack.EMPTY);
+            this.ghostInventory.set(index - 36, ItemResource.of(ItemStack.EMPTY), 0);
             this.getSlot(index).setChanged();
         }
         return ItemStack.EMPTY;

--- a/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
@@ -51,9 +51,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
 
     @Override
     public boolean canDragTo(@NotNull Slot slotIn) {
-        if (this.allowRepeats())
-            return true;
-        return slotIn.container == this.playerInventory;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/gui/menu/GhostItemMenu.java
@@ -4,8 +4,6 @@
 
 package com.klikli_dev.theurgy.content.gui.menu;
 
-import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
-import net.neoforged.neoforge.transfer.item.ItemUtil;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -13,13 +11,12 @@ import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.transfer.item.ItemResource;
-import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.items.ComponentItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearableMenu {
 
-    public SettableItemStorage ghostInventory;
+    public ComponentItemHandler ghostInventory;
 
     protected GhostItemMenu(MenuType<?> type, int id, Inventory inv, RegistryFriendlyByteBuf extraData) {
         super(type, id, inv, extraData);
@@ -29,7 +26,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
         super(type, id, inv, contentHolder);
     }
 
-    protected abstract SettableItemStorage createGhostInventory();
+    protected abstract ComponentItemHandler createGhostInventory();
 
     protected abstract boolean allowRepeats();
 
@@ -40,8 +37,8 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
 
     @Override
     public void clearContents() {
-        for (int i = 0; i < this.ghostInventory.size(); i++)
-            this.ghostInventory.set(i, ItemResource.of(ItemStack.EMPTY), 0);
+        for (int i = 0; i < this.ghostInventory.getSlots(); i++)
+            this.ghostInventory.setStackInSlot(i, ItemStack.EMPTY);
     }
 
     @Override
@@ -51,7 +48,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
 
     @Override
     public boolean canDragTo(@NotNull Slot slotIn) {
-        return true;
+        return this.allowRepeats() || slotIn.container == this.playerInventory;
     }
 
     @Override
@@ -67,7 +64,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
         int slot = slotId - 36;
         if (clickTypeIn == ContainerInput.CLONE) {
             if (player.isCreative() && held.isEmpty()) {
-                ItemStack stackInSlot = ItemUtil.getStack(this.ghostInventory, slot).copy();
+                ItemStack stackInSlot = this.ghostInventory.getStackInSlot(slot).copy();
                 stackInSlot.setCount(stackInSlot.getMaxStackSize());
                 this.setCarried(stackInSlot);
                 return;
@@ -82,7 +79,7 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
             insert = held.copy();
             insert.setCount(1);
         }
-        this.ghostInventory.set(slot, ItemResource.of(insert), insert.getCount());
+        this.ghostInventory.setStackInSlot(slot, insert);
         this.getSlot(slotId).setChanged();
     }
 
@@ -90,26 +87,20 @@ public abstract class GhostItemMenu<T> extends MenuBase<T> implements IClearable
     public @NotNull ItemStack quickMoveStack(@NotNull Player playerIn, int index) {
         if (index < 36) {
             ItemStack stackToInsert = this.playerInventory.getItem(index);
-            for (int i = 0; i < this.ghostInventory.size(); i++) {
-                ItemStack stack = ItemUtil.getStack(this.ghostInventory, i);
+            for (int i = 0; i < this.ghostInventory.getSlots(); i++) {
+                ItemStack stack = this.ghostInventory.getStackInSlot(i);
                 if (!this.allowRepeats() && ItemStack.isSameItemSameComponents(stack, stackToInsert))
                     break;
                 if (stack.isEmpty()) {
                     ItemStack copy = stackToInsert.copy();
                     copy.setCount(1);
-                    try (var tx = Transaction.openRoot()) {
-                        this.ghostInventory.insert(ItemResource.of(copy), 1, tx);
-                        tx.commit();
-                    }
+                    this.ghostInventory.setStackInSlot(i, copy);
                     this.getSlot(i + 36).setChanged();
                     break;
                 }
             }
         } else {
-            try (var tx = Transaction.openRoot()) {
-                this.ghostInventory.extract(ItemResource.of(ItemUtil.getStack(this.ghostInventory, index - 36)), 1, tx);
-                tx.commit();
-            }
+            this.ghostInventory.setStackInSlot(index - 36, ItemStack.EMPTY);
             this.getSlot(index).setChanged();
         }
         return ItemStack.EMPTY;

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterMenu.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.item.filter;
 
 import com.klikli_dev.theurgy.content.gui.menu.GhostItemMenu;
-import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
+import net.neoforged.neoforge.items.ComponentItemHandler;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -25,7 +25,7 @@ public abstract class AbstractFilterMenu extends GhostItemMenu<ItemStack> {
     }
 
     @Override
-    protected abstract SettableItemStorage createGhostInventory();
+    protected abstract ComponentItemHandler createGhostInventory();
 
     @Override
     protected boolean allowRepeats() {

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterMenu.java
@@ -5,7 +5,7 @@
 package com.klikli_dev.theurgy.content.item.filter;
 
 import com.klikli_dev.theurgy.content.gui.menu.GhostItemMenu;
-import net.neoforged.neoforge.items.ComponentItemHandler;
+import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -25,7 +25,7 @@ public abstract class AbstractFilterMenu extends GhostItemMenu<ItemStack> {
     }
 
     @Override
-    protected abstract ComponentItemHandler createGhostInventory();
+    protected abstract SettableItemStorage createGhostInventory();
 
     @Override
     protected boolean allowRepeats() {

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterScreen.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AbstractFilterScreen.java
@@ -98,6 +98,18 @@ public abstract class AbstractFilterScreen<T extends AbstractFilterMenu> extends
         this.updateIndicatorState();
     }
 
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+        for (GuiEventListener listener : this.children()) {
+            if (listener.isMouseOver(mouseX, mouseY) && listener.mouseScrolled(mouseX, mouseY, scrollX, scrollY)) {
+                this.setFocused(listener);
+                return true;
+            }
+        }
+
+        return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
+    }
+
 
     public int getLeftOfCentered(int textureWidth) {
         return this.leftPos + (this.imageWidth - textureWidth) / 2;

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterMenu.java
@@ -6,6 +6,8 @@ package com.klikli_dev.theurgy.content.item.filter;
 
 import com.klikli_dev.theurgy.content.behaviour.filter.FilterMode;
 import com.klikli_dev.theurgy.content.behaviour.filter.attribute.ItemAttribute;
+import com.klikli_dev.theurgy.content.storage.ComponentItemStorage;
+import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
 import com.klikli_dev.theurgy.registry.DataComponentRegistry;
 import com.klikli_dev.theurgy.registry.MenuTypeRegistry;
 import com.mojang.datafixers.util.Pair;
@@ -23,8 +25,8 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
-import net.neoforged.neoforge.items.ComponentItemHandler;
-import net.neoforged.neoforge.items.SlotItemHandler;
+import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
+import net.neoforged.neoforge.transfer.item.ItemResource;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -52,8 +54,8 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
     }
 
     @Override
-    protected ComponentItemHandler createGhostInventory() {
-        return new ComponentItemHandler(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 2);
+    protected SettableItemStorage createGhostInventory() {
+        return new ComponentItemStorage(this.player, this.playerInventory.getSelectedSlot(), DataComponentRegistry.FILTER_ITEMS.get(), 2);
     }
 
     @Override
@@ -68,8 +70,8 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
 
     @Override
     protected void addFilterSlots() {
-        this.addSlot(new SlotItemHandler(this.ghostInventory, 0, 16, 24));
-        this.addSlot(new SlotItemHandler(this.ghostInventory, 1, 22, 59) {
+        this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, resource, amount), 0, 16, 24));
+        this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, resource, amount), 1, 22, 59) {
             @Override
             public boolean mayPickup(@NotNull Player playerIn) {
                 return false;
@@ -84,7 +86,7 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
         ItemStack stack = new ItemStack(Items.NAME_TAG);
         stack.set(DataComponents.ITEM_NAME,
                 Component.literal("Selected Tags").withStyle(ChatFormatting.RESET, ChatFormatting.BLUE));
-        this.ghostInventory.setStackInSlot(1, stack);
+        this.ghostInventory.set(1, ItemResource.of(stack), stack.getCount());
     }
 
     @Override
@@ -113,14 +115,14 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
         if (index == 37)
             return ItemStack.EMPTY;
         if (index == 36) {
-            this.ghostInventory.setStackInSlot(0, ItemStack.EMPTY);
+            this.ghostInventory.set(0, ItemResource.of(ItemStack.EMPTY), 0);
             return ItemStack.EMPTY;
         }
         if (index < 36) {
             ItemStack stackToInsert = this.playerInventory.getItem(index);
             ItemStack copy = stackToInsert.copy();
             copy.setCount(1);
-            this.ghostInventory.setStackInSlot(0, copy);
+            this.ghostInventory.set(0, ItemResource.of(copy), 1);
         }
         return ItemStack.EMPTY;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterMenu.java
@@ -6,7 +6,6 @@ package com.klikli_dev.theurgy.content.item.filter;
 
 import com.klikli_dev.theurgy.content.behaviour.filter.FilterMode;
 import com.klikli_dev.theurgy.content.behaviour.filter.attribute.ItemAttribute;
-import com.klikli_dev.theurgy.content.storage.ComponentItemStorage;
 import com.klikli_dev.theurgy.registry.DataComponentRegistry;
 import com.klikli_dev.theurgy.registry.MenuTypeRegistry;
 import com.mojang.datafixers.util.Pair;
@@ -24,8 +23,8 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
-import net.neoforged.neoforge.transfer.item.ItemResource;
-import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
+import net.neoforged.neoforge.items.ComponentItemHandler;
+import net.neoforged.neoforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -53,8 +52,8 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
     }
 
     @Override
-    protected ComponentItemStorage createGhostInventory() {
-        return new ComponentItemStorage(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 2);
+    protected ComponentItemHandler createGhostInventory() {
+        return new ComponentItemHandler(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 2);
     }
 
     @Override
@@ -69,8 +68,8 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
 
     @Override
     protected void addFilterSlots() {
-        this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, resource, amount), 0, 16, 24));
-        this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, resource, amount), 1, 22, 59) {
+        this.addSlot(new SlotItemHandler(this.ghostInventory, 0, 16, 24));
+        this.addSlot(new SlotItemHandler(this.ghostInventory, 1, 22, 59) {
             @Override
             public boolean mayPickup(@NotNull Player playerIn) {
                 return false;
@@ -85,7 +84,7 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
         ItemStack stack = new ItemStack(Items.NAME_TAG);
         stack.set(DataComponents.ITEM_NAME,
                 Component.literal("Selected Tags").withStyle(ChatFormatting.RESET, ChatFormatting.BLUE));
-        this.ghostInventory.set(1, ItemResource.of(stack), stack.getCount());
+        this.ghostInventory.setStackInSlot(1, stack);
     }
 
     @Override
@@ -114,14 +113,14 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
         if (index == 37)
             return ItemStack.EMPTY;
         if (index == 36) {
-            this.ghostInventory.set(1, ItemResource.of(ItemStack.EMPTY), 0);
+            this.ghostInventory.setStackInSlot(0, ItemStack.EMPTY);
             return ItemStack.EMPTY;
         }
         if (index < 36) {
             ItemStack stackToInsert = this.playerInventory.getItem(index);
             ItemStack copy = stackToInsert.copy();
             copy.setCount(1);
-            this.ghostInventory.set(0, ItemResource.of(copy), copy.getCount());
+            this.ghostInventory.setStackInSlot(0, copy);
         }
         return ItemStack.EMPTY;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterScreen.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterScreen.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix3x2fStack;
+import net.neoforged.neoforge.transfer.item.ItemUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -167,7 +168,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
         this.addRenderableWidget(this.attributeSelector);
 
 
-        this.referenceItemChanged(this.menu.ghostInventory.getStackInSlot(0));
+        this.referenceItemChanged(ItemUtil.getStack(this.menu.ghostInventory, 0));
 
 
         this.selectedAttributes.clear();
@@ -183,7 +184,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
     public void extractRenderState(@NotNull GuiGraphicsExtractor pGuiGraphics, int pMouseX, int pMouseY, float pPartialTick) {
         super.extractRenderState(pGuiGraphics, pMouseX, pMouseY, pPartialTick);
 
-        ItemStack stack = this.menu.ghostInventory.getStackInSlot(1);
+        ItemStack stack = ItemUtil.getStack(this.menu.ghostInventory, 1);
         Matrix3x2fStack matrixStack = pGuiGraphics.pose();
         matrixStack.pushMatrix();
         pGuiGraphics.itemDecorations(this.font, stack, this.leftPos + 22, this.topPos + 59,
@@ -194,7 +195,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
     @Override
     protected void containerTick() {
         super.containerTick();
-        ItemStack stackInSlot = this.menu.ghostInventory.getStackInSlot(0);
+        ItemStack stackInSlot = ItemUtil.getStack(this.menu.ghostInventory, 0);
         if (!ItemStack.isSameItemSameComponents(stackInSlot, this.lastItemScanned))
             this.referenceItemChanged(stackInSlot);
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterScreen.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/AttributeFilterScreen.java
@@ -18,7 +18,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.transfer.item.ItemUtil;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix3x2fStack;
 
@@ -168,7 +167,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
         this.addRenderableWidget(this.attributeSelector);
 
 
-        this.referenceItemChanged(ItemUtil.getStack(this.menu.ghostInventory, 0));
+        this.referenceItemChanged(this.menu.ghostInventory.getStackInSlot(0));
 
 
         this.selectedAttributes.clear();
@@ -184,7 +183,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
     public void extractRenderState(@NotNull GuiGraphicsExtractor pGuiGraphics, int pMouseX, int pMouseY, float pPartialTick) {
         super.extractRenderState(pGuiGraphics, pMouseX, pMouseY, pPartialTick);
 
-        ItemStack stack = ItemUtil.getStack(this.menu.ghostInventory, 1);
+        ItemStack stack = this.menu.ghostInventory.getStackInSlot(1);
         Matrix3x2fStack matrixStack = pGuiGraphics.pose();
         matrixStack.pushMatrix();
         pGuiGraphics.itemDecorations(this.font, stack, this.leftPos + 22, this.topPos + 59,
@@ -195,7 +194,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterM
     @Override
     protected void containerTick() {
         super.containerTick();
-        ItemStack stackInSlot = ItemUtil.getStack(this.menu.ghostInventory, 0);
+        ItemStack stackInSlot = this.menu.ghostInventory.getStackInSlot(0);
         if (!ItemStack.isSameItemSameComponents(stackInSlot, this.lastItemScanned))
             this.referenceItemChanged(stackInSlot);
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/ListFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/ListFilterMenu.java
@@ -4,15 +4,14 @@
 
 package com.klikli_dev.theurgy.content.item.filter;
 
-import com.klikli_dev.theurgy.content.storage.ComponentItemStorage;
 import com.klikli_dev.theurgy.registry.DataComponentRegistry;
 import com.klikli_dev.theurgy.registry.MenuTypeRegistry;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.transfer.item.ItemResource;
-import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
+import net.neoforged.neoforge.items.ComponentItemHandler;
+import net.neoforged.neoforge.items.SlotItemHandler;
 
 public class ListFilterMenu extends AbstractFilterMenu {
 
@@ -37,8 +36,8 @@ public class ListFilterMenu extends AbstractFilterMenu {
     }
 
     @Override
-    protected ComponentItemStorage createGhostInventory() {
-        return new ComponentItemStorage(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 18);
+    protected ComponentItemHandler createGhostInventory() {
+        return new ComponentItemHandler(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 18);
     }
 
     @Override
@@ -57,7 +56,7 @@ public class ListFilterMenu extends AbstractFilterMenu {
         int y = 22;
         for (int row = 0; row < 2; ++row)
             for (int col = 0; col < 9; ++col)
-                this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, ItemResource.of(resource.toStack(amount)), amount), col + row * 9, x + col * 18, y + row * 18));
+                this.addSlot(new SlotItemHandler(this.ghostInventory, col + row * 9, x + col * 18, y + row * 18));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/item/filter/ListFilterMenu.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/item/filter/ListFilterMenu.java
@@ -6,12 +6,13 @@ package com.klikli_dev.theurgy.content.item.filter;
 
 import com.klikli_dev.theurgy.registry.DataComponentRegistry;
 import com.klikli_dev.theurgy.registry.MenuTypeRegistry;
+import com.klikli_dev.theurgy.content.storage.ComponentItemStorage;
+import com.klikli_dev.theurgy.content.storage.SettableItemStorage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.items.ComponentItemHandler;
-import net.neoforged.neoforge.items.SlotItemHandler;
+import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
 
 public class ListFilterMenu extends AbstractFilterMenu {
 
@@ -36,8 +37,8 @@ public class ListFilterMenu extends AbstractFilterMenu {
     }
 
     @Override
-    protected ComponentItemHandler createGhostInventory() {
-        return new ComponentItemHandler(this.contentHolder, DataComponentRegistry.FILTER_ITEMS.get(), 18);
+    protected SettableItemStorage createGhostInventory() {
+        return new ComponentItemStorage(this.player, this.playerInventory.getSelectedSlot(), DataComponentRegistry.FILTER_ITEMS.get(), 18);
     }
 
     @Override
@@ -56,7 +57,7 @@ public class ListFilterMenu extends AbstractFilterMenu {
         int y = 22;
         for (int row = 0; row < 2; ++row)
             for (int col = 0; col < 9; ++col)
-                this.addSlot(new SlotItemHandler(this.ghostInventory, col + row * 9, x + col * 18, y + row * 18));
+                this.addSlot(new ResourceHandlerSlot(this.ghostInventory, (slot, resource, amount) -> this.ghostInventory.set(slot, resource, amount), col + row * 9, x + col * 18, y + row * 18));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/storage/ComponentItemStorage.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/storage/ComponentItemStorage.java
@@ -11,12 +11,13 @@ import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.item.ItemAccessItemHandler;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.minecraft.world.entity.player.Player;
 
 import java.util.Objects;
 
 public class ComponentItemStorage extends ItemAccessItemHandler implements SettableItemStorage {
-    public ComponentItemStorage(ItemStack parent, DataComponentType<ItemContainerContents> component, int size) {
-        super(ItemAccess.forStack(parent), component, size);
+    public ComponentItemStorage(Player player, int selectedSlot, DataComponentType<ItemContainerContents> component, int size) {
+        super(ItemAccess.forPlayerSlot(player, selectedSlot), component, size);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/storage/ComponentItemStorage.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/storage/ComponentItemStorage.java
@@ -20,6 +20,14 @@ public class ComponentItemStorage extends ItemAccessItemHandler implements Setta
     }
 
     @Override
+    public boolean isValid(int slot, ItemResource resource) {
+        // Used for filter ghost inventories: accept any item the UI tries to place.
+        // ResourceHandlerSlot gates placement via isValid(), and ItemAccessItemHandler's
+        // default validation is too strict for component-backed ghost slots.
+        return true;
+    }
+
+    @Override
     public void set(int slot, ItemResource resource, int amount) {
         Objects.checkIndex(slot, this.size());
         if (!resource.isEmpty() && !this.isValid(slot, resource)) {


### PR DESCRIPTION
## Summary
- restore working list and attribute filter ghost slot interactions
- migrate the filter ghost inventories to NeoForge resource handlers using ItemAccessItemHandler backing
- fix attribute filter crashes and selector scroll input handling