### PR TITLE
fix: correct brazier fuel consumption

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
@@ -134,16 +134,7 @@ public class PyromanticBrazierBlockEntity extends BlockEntity implements HeldSta
 
             if (this.isLit()) {
                 wasTurnedOnDuringThisTick = true;
-                //handle lava bucket
-                if (fuelStack.getCraftingRemainder() != null)
-                    this.inventory.set(0, ItemResource.of(fuelStack.getCraftingRemainder().create()), 1);
-                    //handle all other fuel items
-                else if (hasFuel) {
-                    fuelStack.shrink(1);
-                    if (fuelStack.isEmpty()) {
-                        this.inventory.set(0, ItemResource.of(ItemStack.EMPTY), 0);
-                    }
-                }
+                this.consumeFuel(fuelStack);
             }
         }
 
@@ -156,6 +147,18 @@ public class PyromanticBrazierBlockEntity extends BlockEntity implements HeldSta
 
         if (wasTurnedOnDuringThisTick) {
             this.setChanged();
+        }
+    }
+
+    private void consumeFuel(ItemStack fuelStack) {
+        var remainingFuel = fuelStack.copy();
+        remainingFuel.shrink(1);
+        if (remainingFuel.isEmpty()) {
+            var craftingRemainder = fuelStack.getCraftingRemainder();
+            var remainderStack = craftingRemainder != null ? craftingRemainder.create() : ItemStack.EMPTY;
+            this.inventory.set(0, ItemResource.of(remainderStack), remainderStack.getCount());
+        } else {
+            this.inventory.set(0, ItemResource.of(remainingFuel), remainingFuel.getCount());
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/GameTestRegistry.java
@@ -168,6 +168,12 @@ public class GameTestRegistry {
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_FUEL_CONSUMED =
             TEST_FUNCTIONS.register("pyromantic_brazier_fuel_consumed", () -> PyromanticBrazierGameTests::fuelIsConsumedOverTime);
 
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_STACKED_FUEL_SHRINKS =
+            TEST_FUNCTIONS.register("pyromantic_brazier_stacked_fuel_shrinks", () -> PyromanticBrazierGameTests::stackedFuelShrinksWhenConsumed);
+
+    public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_FUEL_LEAVES_REMAINDER =
+            TEST_FUNCTIONS.register("pyromantic_brazier_fuel_leaves_remainder", () -> PyromanticBrazierGameTests::fuelLeavesCraftingRemainder);
+
     public static final DeferredHolder<Consumer<GameTestHelper>, Consumer<GameTestHelper>> BRAZIER_HEAT_CALCINATION_OVEN =
             TEST_FUNCTIONS.register("pyromantic_brazier_heat_calcination_oven", () -> PyromanticBrazierGameTests::providesHeatToCalcinationOven);
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -127,6 +127,50 @@ public class PyromanticBrazierGameTests {
     }
 
     /**
+     * Tests that stacked fuel is decremented when the brazier starts burning.
+     */
+    public static void stackedFuelShrinksWhenConsumed(GameTestHelper helper) {
+        helper.setBlock(BRAZIER_POS, BlockRegistry.PYROMANTIC_BRAZIER.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            blockEntity.inventory.set(0, ItemResource.of(new ItemStack(Items.COAL, 2)), new ItemStack(Items.COAL, 2).getCount());
+        });
+
+        helper.succeedWhen(() -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            var fuelStack = ItemUtil.getStack(blockEntity.inventory, 0);
+            helper.assertBlockProperty(BRAZIER_POS, BlockStateProperties.LIT, true);
+            helper.assertTrue(
+                    fuelStack.is(Items.COAL) && fuelStack.getCount() == 1,
+                    "Stacked fuel should shrink from 2 coal to 1 when the brazier starts burning"
+            );
+        });
+    }
+
+    /**
+     * Tests that fuel with a crafting remainder leaves that remainder behind when consumed.
+     */
+    public static void fuelLeavesCraftingRemainder(GameTestHelper helper) {
+        helper.setBlock(BRAZIER_POS, BlockRegistry.PYROMANTIC_BRAZIER.get());
+
+        helper.runAfterDelay(1, () -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            blockEntity.inventory.set(0, ItemResource.of(new ItemStack(Items.LAVA_BUCKET, 1)), new ItemStack(Items.LAVA_BUCKET, 1).getCount());
+        });
+
+        helper.succeedWhen(() -> {
+            var blockEntity = helper.getBlockEntity(BRAZIER_POS, PyromanticBrazierBlockEntity.class);
+            var fuelStack = ItemUtil.getStack(blockEntity.inventory, 0);
+            helper.assertBlockProperty(BRAZIER_POS, BlockStateProperties.LIT, true);
+            helper.assertTrue(
+                    fuelStack.is(Items.BUCKET) && fuelStack.getCount() == 1,
+                    "Lava bucket fuel should leave one bucket behind when consumed"
+            );
+        });
+    }
+
+    /**
      * Tests that fuel can be removed by right-clicking the brazier with an empty hand.
      * The block's useItemOn handler ejects the fuel into the player's inventory.
      */

--- a/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/PyromanticBrazierGameTests.java
@@ -236,8 +236,8 @@ public class PyromanticBrazierGameTests {
         });
 
         helper.succeedWhen(() -> {
-            // Verify exact count of coal items dropped
-            helper.assertItemEntityCountIs(Items.COAL, BRAZIER_POS, 2.0, 3);
+            // One coal is consumed as soon as the brazier starts burning, so only the remaining fuel drops.
+            helper.assertItemEntityCountIs(Items.COAL, BRAZIER_POS, 2.0, 2);
         });
     }
 


### PR DESCRIPTION
## Summary
- align brazier fuel consumption with vanilla furnace semantics for stacked fuel and crafting remainders
- add brazier gametests for stacked fuel shrink and lava-bucket remainder handling
- update the brazier broken-drop test to match upfront fuel consumption