### PR TITLE
fix: clear contained items from clearable blocks

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationOvenBlockEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +29,7 @@ import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.animation.AnimationController;
 
 
-public class CalcinationOvenBlockEntity extends BlockEntity implements GeoBlockEntity, HasCraftingBehaviour<ItemHandlerRecipeInput, CalcinationRecipe, CalcinationCachedCheck> {
+public class CalcinationOvenBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable, HasCraftingBehaviour<ItemHandlerRecipeInput, CalcinationRecipe, CalcinationCachedCheck> {
 
     public CraftingHeatReceiver heatReceiver;
 
@@ -92,6 +93,11 @@ public class CalcinationOvenBlockEntity extends BlockEntity implements GeoBlockE
         boolean hasInput = !this.storageBehaviour.inputInventory.getStackInSlot(0).isEmpty();
 
         this.craftingBehaviour.tickServer(isHeated, hasInput);
+    }
+
+    @Override
+    public void clearContent() {
+        this.storageBehaviour.clearContent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/calcinationoven/CalcinationStorageBehaviour.java
@@ -68,6 +68,11 @@ public class CalcinationStorageBehaviour extends StorageBehaviour<CalcinationSto
         this.readNetwork(pTag, pRegistries);
     }
 
+    public void clearContent() {
+        clearItemHandler(this.inputInventory);
+        clearItemHandler(this.outputInventory);
+    }
+
 
     public class InputInventory extends MonitoredItemStackHandler {
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionStorageBehaviour.java
@@ -130,6 +130,11 @@ public class DigestionStorageBehaviour extends StorageBehaviour<DigestionStorage
         return this.outputInventory;
     }
 
+    public void clearContent() {
+        clearItemHandler(this.inputInventory);
+        clearItemHandler(this.outputInventory);
+    }
+
     public class WaterTank extends MonitoredFluidTank {
 
         public WaterTank(int capacity, Predicate<FluidStack> validator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionVatBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionVatBlockEntity.java
@@ -19,13 +19,14 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
 
-public class DigestionVatBlockEntity extends BlockEntity implements HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, DigestionRecipe, DigestionCachedCheck>, HasStorageBehaviour<DigestionStorageBehaviour> {
+public class DigestionVatBlockEntity extends BlockEntity implements Clearable, HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, DigestionRecipe, DigestionCachedCheck>, HasStorageBehaviour<DigestionStorageBehaviour> {
 
     public DigestionCraftingBehaviour craftingBehaviour;
     public DigestionStorageBehaviour storageBehaviour;
@@ -101,6 +102,11 @@ public class DigestionVatBlockEntity extends BlockEntity implements HasCraftingB
             }
         }
         return false;
+    }
+
+    @Override
+    public void clearContent() {
+        this.storageBehaviour.clearContent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillationStorageBehaviour.java
@@ -65,6 +65,11 @@ public class DistillationStorageBehaviour extends StorageBehaviour<DistillationS
         this.readNetwork(pTag, pRegistries);
     }
 
+    public void clearContent() {
+        clearItemHandler(this.inputInventory);
+        clearItemHandler(this.outputInventory);
+    }
+
     public class InputInventory extends MonitoredItemStackHandler {
 
         public InputInventory() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/distiller/DistillerBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
@@ -29,7 +30,7 @@ import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.animation.AnimationController;
 
 
-public class DistillerBlockEntity extends BlockEntity implements GeoBlockEntity, HasCraftingBehaviour<ItemHandlerRecipeInput, DistillationRecipe, DistillationCachedCheck> {
+public class DistillerBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable, HasCraftingBehaviour<ItemHandlerRecipeInput, DistillationRecipe, DistillationCachedCheck> {
 
     public CraftingHeatReceiver heatReceiver;
 
@@ -93,6 +94,11 @@ public class DistillerBlockEntity extends BlockEntity implements GeoBlockEntity,
         boolean hasInput = !this.storageBehaviour.inputInventory.getStackInSlot(0).isEmpty();
 
         this.craftingBehaviour.tickServer(isHeated, hasInput);
+    }
+
+    @Override
+    public void clearContent() {
+        this.storageBehaviour.clearContent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationStorageBehaviour.java
@@ -131,6 +131,11 @@ public class FermentationStorageBehaviour extends StorageBehaviour<FermentationS
         return this.outputInventory;
     }
 
+    public void clearContent() {
+        clearItemHandler(this.inputInventory);
+        clearItemHandler(this.outputInventory);
+    }
+
     public class WaterTank extends MonitoredFluidTank {
 
         public WaterTank(int capacity, Predicate<FluidStack> validator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationVatBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationVatBlockEntity.java
@@ -19,13 +19,14 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
 
-public class FermentationVatBlockEntity extends BlockEntity implements HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, FermentationRecipe, FermentationCachedCheck>, HasStorageBehaviour<FermentationStorageBehaviour> {
+public class FermentationVatBlockEntity extends BlockEntity implements Clearable, HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, FermentationRecipe, FermentationCachedCheck>, HasStorageBehaviour<FermentationStorageBehaviour> {
 
     public FermentationStorageBehaviour storageBehaviour;
     public FermentationCraftingBehaviour craftingBehaviour;
@@ -96,6 +97,11 @@ public class FermentationVatBlockEntity extends BlockEntity implements HasCrafti
             }
         }
         return false;
+    }
+
+    @Override
+    public void clearContent() {
+        this.storageBehaviour.clearContent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlockEntity.java
@@ -7,6 +7,7 @@ package com.klikli_dev.theurgy.content.apparatus.incubator;
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.crafting.HasCraftingBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.heat.HeatConsumerBehaviour;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.capability.CraftingHeatReceiver;
 import com.klikli_dev.theurgy.content.capability.DefaultHeatReceiver;
 import com.klikli_dev.theurgy.content.recipe.IncubationRecipe;
@@ -163,9 +164,7 @@ public class IncubatorBlockEntity extends BlockEntity implements Clearable, HasC
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.outputInventory.getSlots(); i++) {
-            this.outputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.outputInventory);
     }
 
     private void checkForVessel(BlockPos pos) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -32,7 +33,7 @@ import net.neoforged.neoforge.items.ItemStackHandler;
 import org.jetbrains.annotations.Nullable;
 
 
-public class IncubatorBlockEntity extends BlockEntity implements HasCraftingBehaviour<IncubatorRecipeInput, IncubationRecipe, RecipeManager.CachedCheck<IncubatorRecipeInput, IncubationRecipe>> {
+public class IncubatorBlockEntity extends BlockEntity implements Clearable, HasCraftingBehaviour<IncubatorRecipeInput, IncubationRecipe, RecipeManager.CachedCheck<IncubatorRecipeInput, IncubationRecipe>> {
     public IncubatorMercuryVesselBlockEntity mercuryVessel;
     public IncubatorSulfurVesselBlockEntity sulfurVessel;
     public IncubatorSaltVesselBlockEntity saltVessel;
@@ -158,6 +159,13 @@ public class IncubatorBlockEntity extends BlockEntity implements HasCraftingBeha
             this.heatReceiver.deserializeNBT(pRegistries, pTag.get("heatReceiver"));
 
         this.readNetwork(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.outputInventory.getSlots(); i++) {
+            this.outputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     private void checkForVessel(BlockPos pos) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlockEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -26,7 +27,7 @@ import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
 
-public class IncubatorMercuryVesselBlockEntity extends BlockEntity implements GeoBlockEntity {
+public class IncubatorMercuryVesselBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable {
 
     protected final AnimatableInstanceCache animatableInstanceCache = GeckoLibUtil.createInstanceCache(this);
     public IncubatorBlockEntity incubator;
@@ -90,6 +91,13 @@ public class IncubatorMercuryVesselBlockEntity extends BlockEntity implements Ge
         super.loadAdditional(pTag, pRegistries);
 
         this.readNetwork(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
+            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorMercuryVesselBlockEntity.java
@@ -4,6 +4,7 @@
 
 package com.klikli_dev.theurgy.content.apparatus.incubator;
 
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -95,9 +96,7 @@ public class IncubatorMercuryVesselBlockEntity extends BlockEntity implements Ge
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
-            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inputInventory);
     }
 
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlockEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -26,7 +27,7 @@ import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
 
-public class IncubatorSaltVesselBlockEntity extends BlockEntity implements GeoBlockEntity {
+public class IncubatorSaltVesselBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable {
 
     protected final AnimatableInstanceCache animatableInstanceCache = GeckoLibUtil.createInstanceCache(this);
 
@@ -92,6 +93,13 @@ public class IncubatorSaltVesselBlockEntity extends BlockEntity implements GeoBl
         super.loadAdditional(pTag, pRegistries);
 
         this.readNetwork(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
+            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     public void setIncubator(IncubatorBlockEntity incubator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSaltVesselBlockEntity.java
@@ -4,6 +4,7 @@
 
 package com.klikli_dev.theurgy.content.apparatus.incubator;
 
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -97,9 +98,7 @@ public class IncubatorSaltVesselBlockEntity extends BlockEntity implements GeoBl
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
-            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inputInventory);
     }
 
     public void setIncubator(IncubatorBlockEntity incubator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlockEntity.java
@@ -4,6 +4,7 @@
 
 package com.klikli_dev.theurgy.content.apparatus.incubator;
 
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -97,9 +98,7 @@ public class IncubatorSulfurVesselBlockEntity extends BlockEntity implements Geo
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
-            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inputInventory);
     }
 
     public void setIncubator(IncubatorBlockEntity incubator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/incubator/IncubatorSulfurVesselBlockEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -26,7 +27,7 @@ import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
 
-public class IncubatorSulfurVesselBlockEntity extends BlockEntity implements GeoBlockEntity {
+public class IncubatorSulfurVesselBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable {
 
     protected final AnimatableInstanceCache animatableInstanceCache = GeckoLibUtil.createInstanceCache(this);
 
@@ -92,6 +93,13 @@ public class IncubatorSulfurVesselBlockEntity extends BlockEntity implements Geo
         super.loadAdditional(pTag, pRegistries);
 
         this.readNetwork(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
+            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     public void setIncubator(IncubatorBlockEntity incubator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCauldronBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCauldronBlockEntity.java
@@ -21,13 +21,14 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 
-public class LiquefactionCauldronBlockEntity extends BlockEntity implements HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, LiquefactionRecipe, LiquefactionCachedCheck> {
+public class LiquefactionCauldronBlockEntity extends BlockEntity implements Clearable, HasCraftingBehaviour<ItemHandlerWithFluidRecipeInput, LiquefactionRecipe, LiquefactionCachedCheck> {
 
     public CraftingHeatReceiver heatReceiver;
 
@@ -111,6 +112,11 @@ public class LiquefactionCauldronBlockEntity extends BlockEntity implements HasC
                 );
             }
         }
+    }
+
+    @Override
+    public void clearContent() {
+        this.storageBehaviour.clearContent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionStorageBehaviour.java
@@ -75,6 +75,11 @@ public class LiquefactionStorageBehaviour extends StorageBehaviour<LiquefactionS
         this.readNetwork(pTag, pRegistries);
     }
 
+    public void clearContent() {
+        clearItemHandler(this.inputInventory);
+        clearItemHandler(this.outputInventory);
+    }
+
     public class SolventTank extends FluidTank {
 
         public SolventTank(int capacity, Predicate<FluidStack> validator) {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsfluidconnector/LogisticsFluidConnectorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsfluidconnector/LogisticsFluidConnectorBlockEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class LogisticsFluidConnectorBlockEntity extends BlockEntity implements HasLeafNodeBehaviour<IFluidHandler, @Nullable Direction>, HasFilterBehaviour, TargetDirectionSetter, EnabledSetter, FrequencySetter {
+public abstract class LogisticsFluidConnectorBlockEntity extends BlockEntity implements Clearable, HasLeafNodeBehaviour<IFluidHandler, @Nullable Direction>, HasFilterBehaviour, TargetDirectionSetter, EnabledSetter, FrequencySetter {
 
     protected LeafNodeBehaviour<IFluidHandler, @Nullable Direction> leafNodeBehaviour;
     protected FilterBehaviour filterBehaviour;
@@ -121,6 +122,11 @@ public abstract class LogisticsFluidConnectorBlockEntity extends BlockEntity imp
             var newState = this.getBlockState().setValue(LogisticsFluidConnectorBlock.HAS_FILTER, !this.filter().filter().isEmpty());
             this.level.setBlock(this.getBlockPos(), newState, Block.UPDATE_ALL);
         }
+    }
+
+    @Override
+    public void clearContent() {
+        this.filterBehaviour.clearContent();
     }
 
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsitemconnector/LogisticsItemConnectorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsitemconnector/LogisticsItemConnectorBlockEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -27,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class LogisticsItemConnectorBlockEntity extends BlockEntity implements HasLeafNodeBehaviour<IItemHandler, @Nullable Direction>, HasFilterBehaviour, TargetDirectionSetter, EnabledSetter, FrequencySetter {
+public abstract class LogisticsItemConnectorBlockEntity extends BlockEntity implements Clearable, HasLeafNodeBehaviour<IItemHandler, @Nullable Direction>, HasFilterBehaviour, TargetDirectionSetter, EnabledSetter, FrequencySetter {
 
     protected LeafNodeBehaviour<IItemHandler, @Nullable Direction> leafNodeBehaviour;
     protected FilterBehaviour filterBehaviour;
@@ -122,6 +123,11 @@ public abstract class LogisticsItemConnectorBlockEntity extends BlockEntity impl
             var newState = this.getBlockState().setValue(LogisticsItemConnectorBlock.HAS_FILTER, !this.filter().filter().isEmpty());
             this.level.setBlock(this.getBlockPos(), newState, Block.UPDATE_ALL);
         }
+    }
+
+    @Override
+    public void clearContent() {
+        this.filterBehaviour.clearContent();
     }
 
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -29,7 +30,7 @@ import net.neoforged.neoforge.items.ItemStackHandler;
 import org.jetbrains.annotations.Nullable;
 
 
-public class MercuryCatalystBlockEntity extends BlockEntity {
+public class MercuryCatalystBlockEntity extends BlockEntity implements Clearable {
 
     public static final int CAPACITY = 50000;
 
@@ -151,6 +152,13 @@ public class MercuryCatalystBlockEntity extends BlockEntity {
             this.mercuryFluxStorage.deserializeNBT(pRegistries, pTag.get("mercuryFluxStorage"));
 
         this.craftingBehaviour.loadAdditional(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inventory.getSlots(); i++) {
+            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/mercurycatalyst/MercuryCatalystBlockEntity.java
@@ -5,6 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.mercurycatalyst;
 
 import com.klikli_dev.theurgy.content.behaviour.crafting.CraftingBehaviour;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.capability.DefaultMercuryFluxStorage;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -156,9 +157,7 @@ public class MercuryCatalystBlockEntity extends BlockEntity implements Clearable
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inventory.getSlots(); i++) {
-            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inventory);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
@@ -5,6 +5,7 @@
 package com.klikli_dev.theurgy.content.apparatus.pyromanticbrazier;
 
 import com.klikli_dev.theurgy.content.apparatus.calcinationoven.CalcinationOvenBlock;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.capability.HeatProvider;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -165,9 +166,7 @@ public class PyromanticBrazierBlockEntity extends BlockEntity implements Clearab
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inventory.getSlots(); i++) {
-            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inventory);
     }
 
     private class Inventory extends MonitoredItemStackHandler {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/pyromanticbrazier/PyromanticBrazierBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -27,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 
-public class PyromanticBrazierBlockEntity extends BlockEntity {
+public class PyromanticBrazierBlockEntity extends BlockEntity implements Clearable {
     public ItemStackHandler inventory;
 
     public HeatProvider heatProvider;
@@ -160,6 +161,13 @@ public class PyromanticBrazierBlockEntity extends BlockEntity {
             this.remainingLitTime = pTag.getShort("remainingLitTime");
 
         this.readNetwork(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inventory.getSlots(); i++) {
+            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     private class Inventory extends MonitoredItemStackHandler {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 
-public class ReformationResultPedestalBlockEntity extends BlockEntity {
+public class ReformationResultPedestalBlockEntity extends BlockEntity implements Clearable {
 
     /**
      * The underlying outputInventory which allows inserting too - we use this when crafting.
@@ -122,6 +123,13 @@ public class ReformationResultPedestalBlockEntity extends BlockEntity {
         this.showParticles = !this.outputInventory.getStackInSlot(0).isEmpty();
         pTag.putBoolean("showParticles", this.showParticles);
         pTag.put("outputInventory", this.outputInventory.serializeNBT(pRegistries));
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.outputInventory.getSlots(); i++) {
+            this.outputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationResultPedestalBlockEntity.java
@@ -6,6 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.particle.ParticleColor;
 import com.klikli_dev.theurgy.content.particle.glow.GlowParticleProvider;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.content.storage.PreventInsertWrapper;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
@@ -127,9 +128,7 @@ public class ReformationResultPedestalBlockEntity extends BlockEntity implements
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.outputInventory.getSlots(); i++) {
-            this.outputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.outputInventory);
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlockEntity.java
@@ -6,6 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.particle.ParticleColor;
 import com.klikli_dev.theurgy.content.particle.glow.GlowParticleProvider;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -119,9 +120,7 @@ public class ReformationSourcePedestalBlockEntity extends BlockEntity implements
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
-            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inputInventory);
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationSourcePedestalBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 
-public class ReformationSourcePedestalBlockEntity extends BlockEntity {
+public class ReformationSourcePedestalBlockEntity extends BlockEntity implements Clearable {
 
     public ItemStackHandler inputInventory;
 
@@ -114,6 +115,13 @@ public class ReformationSourcePedestalBlockEntity extends BlockEntity {
         this.showParticles = !this.inputInventory.getStackInSlot(0).isEmpty();
         pTag.putBoolean("showParticles", this.showParticles);
         pTag.put("inputInventory", this.inputInventory.serializeNBT(pRegistries));
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
+            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlockEntity.java
@@ -6,6 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.reformationarray;
 
 import com.klikli_dev.theurgy.content.particle.ParticleColor;
 import com.klikli_dev.theurgy.content.particle.glow.GlowParticleProvider;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -116,9 +117,7 @@ public class ReformationTargetPedestalBlockEntity extends BlockEntity implements
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
-            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inputInventory);
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/reformationarray/ReformationTargetPedestalBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 
-public class ReformationTargetPedestalBlockEntity extends BlockEntity {
+public class ReformationTargetPedestalBlockEntity extends BlockEntity implements Clearable {
 
     public ItemStackHandler inputInventory;
 
@@ -111,6 +112,13 @@ public class ReformationTargetPedestalBlockEntity extends BlockEntity {
         this.showParticles = !this.inputInventory.getStackInSlot(0).isEmpty();
         pTag.putBoolean("showParticles", this.showParticles);
         pTag.put("inputInventory", this.inputInventory.serializeNBT(pRegistries));
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inputInventory.getSlots(); i++) {
+            this.inputInventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     public void sendBlockUpdated() {

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -36,7 +37,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 import java.util.function.Predicate;
 
-public class SalAmmoniacAccumulatorBlockEntity extends BlockEntity implements GeoBlockEntity {
+public class SalAmmoniacAccumulatorBlockEntity extends BlockEntity implements GeoBlockEntity, Clearable {
 
     protected final AnimatableInstanceCache animatableInstanceCache = GeckoLibUtil.createInstanceCache(this);
 
@@ -192,6 +193,13 @@ public class SalAmmoniacAccumulatorBlockEntity extends BlockEntity implements Ge
         }
 
         this.craftingBehaviour.loadAdditional(pTag, pRegistries);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.inventory.getSlots(); i++) {
+            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlockEntity.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorBlockEntity.java
@@ -6,6 +6,7 @@ package com.klikli_dev.theurgy.content.apparatus.salammoniacaccumulator;
 
 import com.klikli_dev.theurgy.content.particle.ParticleColor;
 import com.klikli_dev.theurgy.content.particle.coloredbubble.ColoredBubbleParticleProvider;
+import com.klikli_dev.theurgy.content.behaviour.storage.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.MonitoredItemStackHandler;
 import com.klikli_dev.theurgy.registry.BlockEntityRegistry;
 import com.klikli_dev.theurgy.registry.ItemTagRegistry;
@@ -197,9 +198,7 @@ public class SalAmmoniacAccumulatorBlockEntity extends BlockEntity implements Ge
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.inventory.getSlots(); i++) {
-            this.inventory.setStackInSlot(i, ItemStack.EMPTY);
-        }
+        StorageBehaviour.clearItemHandler(this.inventory);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/filter/FilterBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/filter/FilterBehaviour.java
@@ -114,4 +114,8 @@ public class FilterBehaviour {
             Containers.dropItemStack(pLevel, pPos.getX(), pPos.getY(), pPos.getZ(), stack);
         }
     }
+
+    public void clearContent() {
+        this.filter(Filter.empty());
+    }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/storage/StorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/storage/StorageBehaviour.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
+import net.neoforged.neoforge.items.ItemStackHandler;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -74,5 +75,11 @@ public abstract class StorageBehaviour<S extends StorageBehaviour<?>> {
 
     protected void setChanged() {
         this.blockEntity.setChanged();
+    }
+
+    protected static void clearItemHandler(ItemStackHandler handler) {
+        for (int i = 0; i < handler.getSlots(); i++) {
+            handler.setStackInSlot(i, ItemStack.EMPTY);
+        }
     }
 }

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/storage/StorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/storage/StorageBehaviour.java
@@ -77,7 +77,7 @@ public abstract class StorageBehaviour<S extends StorageBehaviour<?>> {
         this.blockEntity.setChanged();
     }
 
-    protected static void clearItemHandler(ItemStackHandler handler) {
+    public static void clearItemHandler(ItemStackHandler handler) {
         for (int i = 0; i < handler.getSlots(); i++) {
             handler.setStackInSlot(i, ItemStack.EMPTY);
         }


### PR DESCRIPTION
## Summary
- add Clearable support to apparatus block entities that store dropped item contents
- clear storage-backed machine inventories and logistics filters through Clearable delegates
- keep normal block break drops intact while ensuring non-drop clears remove contained items

Fixes #360