### PR TITLE
feat: add configurable wire line width in client config

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/config/ClientConfig.java
+++ b/src/main/java/com/klikli_dev/theurgy/config/ClientConfig.java
@@ -7,6 +7,7 @@ package com.klikli_dev.theurgy.config;
 import com.klikli_dev.theurgy.content.render.HeldStackFitRenderMode;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import net.neoforged.neoforge.common.ModConfigSpec.BooleanValue;
+import net.neoforged.neoforge.common.ModConfigSpec.IntValue;
 
 public class ClientConfig {
 
@@ -34,6 +35,7 @@ public class ClientConfig {
         public final BooleanValue enableHeldStackFitOutline;
         public final ModConfigSpec.EnumValue<HeldStackFitRenderMode> heldStackFitOutlineRenderMode;
         public final ModConfigSpec.DoubleValue itemHUDScale;
+        public final IntValue wireLineWidth;
 
         public Rendering(ModConfigSpec.Builder builder) {
             builder.comment("Rendering Settings").push("rendering");
@@ -63,6 +65,11 @@ public class ClientConfig {
             this.itemHUDScale = builder
                     .comment("The scale of the Item HUD text (e.g. for the mercurial wand).")
                     .defineInRange("hudScale", 0.7, 0.25, 3);
+
+            this.wireLineWidth = builder
+                    .comment("The line width of wires rendered in-world. Higher values produce thicker wires.",
+                            "Note: Line width rendering is platform-dependent and may be limited to 1 on some GPUs.")
+                    .defineInRange("wireLineWidth", 1, 1, 16);
 
             builder.pop();
         }

--- a/src/main/java/com/klikli_dev/theurgy/logistics/WireRenderer.java
+++ b/src/main/java/com/klikli_dev/theurgy/logistics/WireRenderer.java
@@ -7,6 +7,7 @@
 
 package com.klikli_dev.theurgy.logistics;
 
+import com.klikli_dev.theurgy.config.ClientConfig;
 import com.klikli_dev.theurgy.content.render.RenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -33,7 +34,7 @@ public class WireRenderer {
         var minecraft = Minecraft.getInstance();
         var bufferSource = minecraft.renderBuffers().bufferSource();
         var poseStack = event.getPoseStack();
-        float lineWidth = minecraft.getWindow().getAppropriateLineWidth();
+        float lineWidth = minecraft.getWindow().getAppropriateLineWidth() * ClientConfig.get().rendering.wireLineWidth.get();
 
         EntityRenderDispatcher erd = minecraft.getEntityRenderDispatcher();
         double renderPosX = erd.camera.position().x();


### PR DESCRIPTION
## Changes
 
Add wireLineWidth option (range: 1-16, default: 1) to the client config's 
endering section. The WireRenderer now multiplies the platform's base line width by this config value, allowing users to adjust wire thickness.
 
## Live reload
 
The config value is read fresh each render frame, so changes take effect immediately without restarting the game.
 