### PR TITLE
Fix NoClassDefFoundError crash with CC:Tweaked

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/util/ClientLevelUtil.java
+++ b/src/main/java/com/klikli_dev/theurgy/util/ClientLevelUtil.java
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.theurgy.util;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.level.Level;
+
+/**
+ * Isolates access to client-only classes (e.g. {@link net.minecraft.client.multiplayer.ClientLevel}).
+ * Keeping this in its own class prevents the dedicated server from having to resolve those classes
+ * during bytecode verification of {@link LevelUtil}, which would throw a NoClassDefFoundError even
+ * if the client-only branch is never actually executed on the server.
+ */
+public class ClientLevelUtil {
+
+    public static Level getClientLevel() {
+        return Minecraft.getInstance().level;
+    }
+}

--- a/src/main/java/com/klikli_dev/theurgy/util/ClientLevelUtil.java
+++ b/src/main/java/com/klikli_dev/theurgy/util/ClientLevelUtil.java
@@ -13,7 +13,10 @@ import net.minecraft.world.level.Level;
  * during bytecode verification of {@link LevelUtil}, which would throw a NoClassDefFoundError even
  * if the client-only branch is never actually executed on the server.
  */
-public class ClientLevelUtil {
+class ClientLevelUtil {
+
+    private ClientLevelUtil() {
+    }
 
     public static Level getClientLevel() {
         return Minecraft.getInstance().level;

--- a/src/main/java/com/klikli_dev/theurgy/util/LevelUtil.java
+++ b/src/main/java/com/klikli_dev/theurgy/util/LevelUtil.java
@@ -4,8 +4,9 @@
 
 package com.klikli_dev.theurgy.util;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.world.level.Level;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 
@@ -15,13 +16,21 @@ public class LevelUtil {
      * Attempts to get a level if there is no context.
      * This is generally needed if items want to access recipes but are not provided a world context.
      * Very hacky, do not use unless absolutely necessary.
+     * <p>
+     * Note: the client-only fallback lives in {@link ClientLevelUtil} on purpose -- referencing
+     * client-only classes (like ClientLevel) directly in this method would make the dedicated
+     * server throw a NoClassDefFoundError as soon as this method is verified/linked, even though
+     * that branch would never be taken on the server.
      */
     public static Level getLevelWithoutContext() {
         Level serverLevel = getOverworldServerLevel();
         if (serverLevel != null) {
             return serverLevel;
         }
-        return Minecraft.getInstance().level;
+        if (FMLEnvironment.getDist() == Dist.CLIENT) {
+            return ClientLevelUtil.getClientLevel();
+        }
+        return null;
     }
 
     private static Level getOverworldServerLevel() {


### PR DESCRIPTION
## Summary
Fixes a dedicated-server crash on startup when CC: Tweaked is installed: `NoClassDefFoundError: net/minecraft/client/multiplayer/ClientLevel`.

## Root cause
CC: Tweaked's `CommonHooks.onServerStarted` forces a rebuild of all creative-mode-tab contents on the server thread (normally client-only). This runs `DivinationRodItem.registerCreativeModeTabs`, which calls `LevelUtil.getLevelWithoutContext()`.

That method mixed a server-safe path with a client-only fallback (`Minecraft.getInstance().level`) in the same method body. Even though the fallback branch is never reached on a dedicated server, referencing the client-only `ClientLevel` type inside the method causes the JVM to throw `NoClassDefFoundError` as soon as the method is verified/linked — the dedicated server jar doesn't ship client classes, so verification fails regardless of which branch actually executes at runtime.

## Change
- Moved the client-only `Minecraft.getInstance().level` access into a new `ClientLevelUtil` class.
- `LevelUtil.getLevelWithoutContext()` now only calls into `ClientLevelUtil` behind an explicit `FMLEnvironment.getDist() == Dist.CLIENT` check, so the dedicated server never needs to link a class referencing `ClientLevel`.
- No behavior change for existing callers (`DivinationRodItem`, `SaltRegistry`, `SulfurRegistry`) — they already null-check the result.

## Testing
- `./gradlew compileJava` succeeds.
- Built the jar and confirmed the dedicated server starts cleanly with CC: Tweaked installed (previously crashed immediately on `ServerStartedEvent`).
