### PR TITLE
feat(salts): add direct calcination recipes for creature salt

### DIFF
--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_armadillo_scute.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_armadillo_scute.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:armadillo_scute"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_arrow.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_arrow.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:arrow"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_beef.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_beef.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:beef"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_blaze_rod.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_blaze_rod.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:blaze_rod"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_bone.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_bone.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:bone"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_bone_meal.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_bone_meal.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:bone_meal"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_chicken.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_chicken.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:chicken"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cod.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cod.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cod"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_beef.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_beef.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_beef"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_chicken.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_chicken.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_chicken"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_cod.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_cod.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_cod"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_mutton.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_mutton.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_mutton"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_porkchop.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_porkchop.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_porkchop"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_rabbit.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_rabbit.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_rabbit"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_salmon.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_cooked_salmon.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:cooked_salmon"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_dragon_egg.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_dragon_egg.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:dragon_egg"
+  },
+  "result": {
+    "count": 5,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_egg.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_egg.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:egg"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_elytra.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_elytra.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:elytra"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ender_pearl.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ender_pearl.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:ender_pearl"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_feather.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_feather.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:feather"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ghast_tear.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ghast_tear.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:ghast_tear"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_glow_ink_sac.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_glow_ink_sac.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:glow_ink_sac"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_gunpowder.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_gunpowder.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:gunpowder"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_heart_of_the_sea.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_heart_of_the_sea.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:heart_of_the_sea"
+  },
+  "result": {
+    "count": 5,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ink_sac.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_ink_sac.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:ink_sac"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_leather.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_leather.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:leather"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_magma_cream.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_magma_cream.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:magma_cream"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_mutton.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_mutton.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:mutton"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_nether_star.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_nether_star.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:nether_star"
+  },
+  "result": {
+    "count": 5,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_phantom_membrane.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_phantom_membrane.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:phantom_membrane"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_porkchop.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_porkchop.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:porkchop"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_prismarine_crystals.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_prismarine_crystals.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:prismarine_crystals"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_prismarine_shard.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_prismarine_shard.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:prismarine_shard"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_pufferfish.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_pufferfish.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:pufferfish"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:rabbit"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit_foot.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit_foot.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:rabbit_foot"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit_hide.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rabbit_hide.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:rabbit_hide"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rotten_flesh.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_rotten_flesh.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:rotten_flesh"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_salmon.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_salmon.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:salmon"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_shulker_shell.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_shulker_shell.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:shulker_shell"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_skeleton_skull.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_skeleton_skull.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:skeleton_skull"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_slime_ball.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_slime_ball.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:slime_ball"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_spider_eye.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_spider_eye.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:spider_eye"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_string.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_string.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:string"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_tropical_fish.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_tropical_fish.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:tropical_fish"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_turtle_scute.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_turtle_scute.json
@@ -1,0 +1,12 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:turtle_scute"
+  },
+  "result": {
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_wither_skeleton_skull.json
+++ b/src/generated/resources/data/theurgy/recipe/calcination/alchemical_salt_creature_from_wither_skeleton_skull.json
@@ -1,0 +1,13 @@
+{
+  "type": "theurgy:calcination",
+  "category": "misc",
+  "ingredient": {
+    "count": 1,
+    "ingredient": "minecraft:wither_skeleton_skull"
+  },
+  "result": {
+    "count": 3,
+    "id": "theurgy:alchemical_salt_creature"
+  },
+  "time": 100
+}

--- a/src/generated/resources/data/theurgy/tags/item/creature_items.json
+++ b/src/generated/resources/data/theurgy/tags/item/creature_items.json
@@ -1,0 +1,16 @@
+{
+  "values": [
+    {
+      "id": "#theurgy:creature_items/animals",
+      "required": false
+    },
+    {
+      "id": "#theurgy:creature_items/fish",
+      "required": false
+    },
+    {
+      "id": "#theurgy:creature_items/mobs",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/theurgy/tags/item/creature_items/animals.json
+++ b/src/generated/resources/data/theurgy/tags/item/creature_items/animals.json
@@ -1,0 +1,22 @@
+{
+  "values": [
+    "minecraft:porkchop",
+    "minecraft:beef",
+    "minecraft:mutton",
+    "minecraft:chicken",
+    "minecraft:cooked_porkchop",
+    "minecraft:cooked_beef",
+    "minecraft:cooked_mutton",
+    "minecraft:cooked_chicken",
+    "minecraft:rabbit",
+    "minecraft:cooked_rabbit",
+    "minecraft:leather",
+    "minecraft:feather",
+    "minecraft:egg",
+    "minecraft:rabbit_hide",
+    "minecraft:ink_sac",
+    "minecraft:glow_ink_sac",
+    "minecraft:armadillo_scute",
+    "#minecraft:wool"
+  ]
+}

--- a/src/generated/resources/data/theurgy/tags/item/creature_items/fish.json
+++ b/src/generated/resources/data/theurgy/tags/item/creature_items/fish.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:cod",
+    "minecraft:cooked_cod",
+    "minecraft:salmon",
+    "minecraft:cooked_salmon",
+    "minecraft:tropical_fish",
+    "minecraft:pufferfish"
+  ]
+}

--- a/src/generated/resources/data/theurgy/tags/item/creature_items/mobs.json
+++ b/src/generated/resources/data/theurgy/tags/item/creature_items/mobs.json
@@ -1,0 +1,27 @@
+{
+  "values": [
+    "minecraft:rotten_flesh",
+    "minecraft:spider_eye",
+    "minecraft:string",
+    "minecraft:gunpowder",
+    "minecraft:bone",
+    "minecraft:bone_meal",
+    "minecraft:arrow",
+    "minecraft:slime_ball",
+    "minecraft:blaze_rod",
+    "minecraft:phantom_membrane",
+    "minecraft:magma_cream",
+    "minecraft:turtle_scute",
+    "minecraft:shulker_shell",
+    "minecraft:ender_pearl",
+    "minecraft:prismarine_shard",
+    "minecraft:prismarine_crystals",
+    "minecraft:skeleton_skull",
+    "minecraft:wither_skeleton_skull",
+    "minecraft:ghast_tear",
+    "minecraft:elytra",
+    "minecraft:nether_star",
+    "minecraft:dragon_egg",
+    "minecraft:heart_of_the_sea"
+  ]
+}

--- a/src/main/java/com/klikli_dev/theurgy/datagen/recipe/CalcinationRecipeProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/recipe/CalcinationRecipeProvider.java
@@ -75,6 +75,65 @@ public class CalcinationRecipeProvider extends JsonRecipeProvider {
         this.makeRecipe("_from_leaves", new Builder(SaltRegistry.PLANT).sizedIngredient(ItemTags.LEAVES));
         this.makeRecipe("_from_saplings", new Builder(SaltRegistry.PLANT).sizedIngredient(ItemTags.SAPLINGS));
         this.makeRecipe("_from_plant_salt", new Builder(SaltRegistry.CREATURE).sizedIngredient(SaltRegistry.PLANT.get(), 2));
+
+        //creature items from animals
+        this.makeRecipe("_from_beef", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.BEEF));
+        this.makeRecipe("_from_porkchop", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.PORKCHOP));
+        this.makeRecipe("_from_mutton", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.MUTTON));
+        this.makeRecipe("_from_chicken", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.CHICKEN));
+        this.makeRecipe("_from_cooked_beef", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_BEEF));
+        this.makeRecipe("_from_cooked_porkchop", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_PORKCHOP));
+        this.makeRecipe("_from_cooked_mutton", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_MUTTON));
+        this.makeRecipe("_from_cooked_chicken", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_CHICKEN));
+        this.makeRecipe("_from_rabbit", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.RABBIT));
+        this.makeRecipe("_from_cooked_rabbit", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_RABBIT));
+        this.makeRecipe("_from_leather", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.LEATHER));
+        this.makeRecipe("_from_feather", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.FEATHER));
+        this.makeRecipe("_from_egg", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.EGG));
+        this.makeRecipe("_from_rabbit_hide", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.RABBIT_HIDE));
+        this.makeRecipe("_from_ink_sac", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.INK_SAC));
+        this.makeRecipe("_from_glow_ink_sac", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.GLOW_INK_SAC));
+        this.makeRecipe("_from_turtle_scute", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.TURTLE_SCUTE));
+        this.makeRecipe("_from_armadillo_scute", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.ARMADILLO_SCUTE));
+
+        //creature items from fish
+        this.makeRecipe("_from_cod", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COD));
+        this.makeRecipe("_from_cooked_cod", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_COD));
+        this.makeRecipe("_from_salmon", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.SALMON));
+        this.makeRecipe("_from_cooked_salmon", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.COOKED_SALMON));
+        this.makeRecipe("_from_tropical_fish", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.TROPICAL_FISH));
+        this.makeRecipe("_from_pufferfish", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.PUFFERFISH));
+
+        //creature items from mobs - abundant (1 salt)
+        this.makeRecipe("_from_rotten_flesh", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.ROTTEN_FLESH));
+        this.makeRecipe("_from_spider_eye", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.SPIDER_EYE));
+        this.makeRecipe("_from_string", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.STRING));
+        this.makeRecipe("_from_gunpowder", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.GUNPOWDER));
+        this.makeRecipe("_from_bone", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.BONE));
+        this.makeRecipe("_from_bone_meal", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.BONE_MEAL));
+        this.makeRecipe("_from_arrow", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.ARROW));
+
+        //creature items from mobs - common (1 salt)
+        this.makeRecipe("_from_slime_ball", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.SLIME_BALL));
+        this.makeRecipe("_from_blaze_rod", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.BLAZE_ROD));
+        this.makeRecipe("_from_phantom_membrane", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.PHANTOM_MEMBRANE));
+        this.makeRecipe("_from_magma_cream", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.MAGMA_CREAM));
+        this.makeRecipe("_from_skeleton_skull", new Builder(SaltRegistry.CREATURE).sizedIngredient(Items.SKELETON_SKULL));
+
+        //creature items from mobs - rare (3 salt)
+        this.makeRecipe("_from_ender_pearl", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.ENDER_PEARL));
+        this.makeRecipe("_from_prismarine_shard", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.PRISMARINE_SHARD));
+        this.makeRecipe("_from_prismarine_crystals", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.PRISMARINE_CRYSTALS));
+        this.makeRecipe("_from_wither_skeleton_skull", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.WITHER_SKELETON_SKULL));
+        this.makeRecipe("_from_ghast_tear", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.GHAST_TEAR));
+        this.makeRecipe("_from_shulker_shell", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.SHULKER_SHELL));
+        this.makeRecipe("_from_rabbit_foot", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.RABBIT_FOOT));
+        this.makeRecipe("_from_elytra", new Builder(SaltRegistry.CREATURE, 3).sizedIngredient(Items.ELYTRA));
+
+        //creature items from mobs - precious (5 salt)
+        this.makeRecipe("_from_nether_star", new Builder(SaltRegistry.CREATURE, 5).sizedIngredient(Items.NETHER_STAR));
+        this.makeRecipe("_from_dragon_egg", new Builder(SaltRegistry.CREATURE, 5).sizedIngredient(Items.DRAGON_EGG));
+        this.makeRecipe("_from_heart_of_the_sea", new Builder(SaltRegistry.CREATURE, 5).sizedIngredient(Items.HEART_OF_THE_SEA));
     }
 
 

--- a/src/main/java/com/klikli_dev/theurgy/datagen/tag/TheurgyItemTagsProvider.java
+++ b/src/main/java/com/klikli_dev/theurgy/datagen/tag/TheurgyItemTagsProvider.java
@@ -462,6 +462,65 @@ public class TheurgyItemTagsProvider extends IntrinsicHolderTagsProvider<Item> {
         //  .addOptionalTag(ItemTagRegistry.GEMS_SULFUR) sulfur is classified as a gem, so its handled in the Tags.Items.GEMS
         ;
 
+        //Creature items that can be calcinated into creature salt
+        this.tag(ItemTagRegistry.CREATURE_ITEMS_ANIMALS)
+                .add(Items.PORKCHOP)
+                .add(Items.BEEF)
+                .add(Items.MUTTON)
+                .add(Items.CHICKEN)
+                .add(Items.COOKED_PORKCHOP)
+                .add(Items.COOKED_BEEF)
+                .add(Items.COOKED_MUTTON)
+                .add(Items.COOKED_CHICKEN)
+                .add(Items.RABBIT)
+                .add(Items.COOKED_RABBIT)
+                .add(Items.LEATHER)
+                .add(Items.FEATHER)
+                .add(Items.EGG)
+                .add(Items.RABBIT_HIDE)
+                .add(Items.INK_SAC)
+                .add(Items.GLOW_INK_SAC)
+                .add(Items.ARMADILLO_SCUTE)
+                .addTag(ItemTags.WOOL);
+
+        this.tag(ItemTagRegistry.CREATURE_ITEMS_FISH)
+                .add(Items.COD)
+                .add(Items.COOKED_COD)
+                .add(Items.SALMON)
+                .add(Items.COOKED_SALMON)
+                .add(Items.TROPICAL_FISH)
+                .add(Items.PUFFERFISH);
+
+        this.tag(ItemTagRegistry.CREATURE_ITEMS_MOBS)
+                .add(Items.ROTTEN_FLESH)
+                .add(Items.SPIDER_EYE)
+                .add(Items.STRING)
+                .add(Items.GUNPOWDER)
+                .add(Items.BONE)
+                .add(Items.BONE_MEAL)
+                .add(Items.ARROW)
+                .add(Items.SLIME_BALL)
+                .add(Items.BLAZE_ROD)
+                .add(Items.PHANTOM_MEMBRANE)
+                .add(Items.MAGMA_CREAM)
+                .add(Items.TURTLE_SCUTE)
+                .add(Items.SHULKER_SHELL)
+                .add(Items.ENDER_PEARL)
+                .add(Items.PRISMARINE_SHARD)
+                .add(Items.PRISMARINE_CRYSTALS)
+                .add(Items.SKELETON_SKULL)
+                .add(Items.WITHER_SKELETON_SKULL)
+                .add(Items.GHAST_TEAR)
+                .add(Items.ELYTRA)
+                .add(Items.NETHER_STAR)
+                .add(Items.DRAGON_EGG)
+                .add(Items.HEART_OF_THE_SEA);
+
+        this.tag(ItemTagRegistry.CREATURE_ITEMS)
+                .addOptionalTag(ItemTagRegistry.CREATURE_ITEMS_ANIMALS)
+                .addOptionalTag(ItemTagRegistry.CREATURE_ITEMS_FISH)
+                .addOptionalTag(ItemTagRegistry.CREATURE_ITEMS_MOBS);
+
 
         //Set up tags for other mods that may not properly tag their mats
         this.tag(ItemTagRegistry.INGOTS_URANINITE)

--- a/src/main/java/com/klikli_dev/theurgy/registry/ItemTagRegistry.java
+++ b/src/main/java/com/klikli_dev/theurgy/registry/ItemTagRegistry.java
@@ -20,6 +20,12 @@ public class ItemTagRegistry {
     //complementary tag to Tags.Items.ORES, Tags.Items.RAW_MATERIALS, Tags.Items.INGOTS and Tags.Items.GEMS
     public static final TagKey<Item> OTHER_MINERALS = tag("other_minerals");
 
+    //Creature items that can be calcinated into creature salt
+    public static final TagKey<Item> CREATURE_ITEMS = tag("creature_items");
+    public static final TagKey<Item> CREATURE_ITEMS_ANIMALS = tag("creature_items/animals");
+    public static final TagKey<Item> CREATURE_ITEMS_MOBS = tag("creature_items/mobs");
+    public static final TagKey<Item> CREATURE_ITEMS_FISH = tag("creature_items/fish");
+
     public static final TagKey<Item> ALCHEMICAL_SULFURS_AND_NITERS = tag("alchemical_sulfurs_and_niters");
     public static final TagKey<Item> ALCHEMICAL_NITERS = tag("alchemical_niters");
     public static final TagKey<Item> ALCHEMICAL_SULFURS = tag("alchemical_sulfurs");


### PR DESCRIPTION
Previously, creature salt could only be obtained by calcinating 2 plant salts. This created an illogical crafting chain where creature-related items (bones, meat, leather, etc.) could not be directly calcinated into creature salt, unlike all other salt types.

This adds 47 new calcination recipes with tiered yields:
- 1 salt: common items (beef, leather, bone, rotten flesh, etc.)
- 3 salt: rare items (ender pearl, blaze rod, ghast tear, elytra, etc.)
- 5 salt: precious items (nether star, dragon egg, heart of the sea)

Also adds creature_items tag hierarchy for use by other systems:
- theurgy:creature_items (master tag)
- theurgy:creature_items/animals (meat, leather, feathers, wool, etc.)
- theurgy:creature_items/mobs (mob drops)
- theurgy:creature_items/fish (cod, salmon, etc.)

The existing 2x plant salt → creature salt recipe is preserved.

Closes #384 (separate PR for 1.21.1 follows)