### PR TITLE
perf: replace per-chunk wire sync scanning with per-player reference counting

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/Theurgy.java
+++ b/src/main/java/com/klikli_dev/theurgy/Theurgy.java
@@ -73,7 +73,9 @@ import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import org.slf4j.Logger;
 
@@ -126,6 +128,8 @@ public class Theurgy {
         NeoForge.EVENT_BUS.addListener(Wires::onLevelUnload);
         NeoForge.EVENT_BUS.addListener(WireSync.get()::onChunkWatch);
         NeoForge.EVENT_BUS.addListener(WireSync.get()::onChunkUnWatch);
+        NeoForge.EVENT_BUS.addListener(WireSync.get()::onServerTick);
+        NeoForge.EVENT_BUS.addListener(WireSync.get()::onPlayerLoggedOut);
         NeoForge.EVENT_BUS.addListener(TheurgyRecipeManager.get()::onDatapackSync);
 
         if (FMLEnvironment.getDist() == Dist.CLIENT) {

--- a/src/main/java/com/klikli_dev/theurgy/logistics/WireSync.java
+++ b/src/main/java/com/klikli_dev/theurgy/logistics/WireSync.java
@@ -9,43 +9,48 @@ import com.google.common.collect.SetMultimap;
 import com.klikli_dev.theurgy.network.Networking;
 import com.klikli_dev.theurgy.network.messages.MessageAddWires;
 import com.klikli_dev.theurgy.network.messages.MessageRemoveWires;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 public class WireSync {
     private static final WireSync instance = new WireSync();
 
-    /**
-     * one player can watch multiple chunks, and one chunk can be watched by multiple players, so we need a multimap
-     * we do not need to keep track of the level, because if a player changes level he will unwatch all chunkPos in that level
-     */
-    private final SetMultimap<UUID, ChunkPos> playerToWatchedChunk = HashMultimap.create();
-    /**
-     * Reverse map to allow lookup of all players watching a chunk
-     */
-    private final SetMultimap<ChunkPos, UUID> watchedChunkToPlayers = HashMultimap.create();
+    private final Map<UUID, PlayerWireState> playerWireStates = new Object2ObjectOpenHashMap<>();
+    private final SetMultimap<Wire, UUID> wireToWatchingPlayers = HashMultimap.create();
 
     public static WireSync get() {
         return instance;
     }
 
+    private static final class PlayerWireState {
+        private final Set<ChunkPos> watchedChunks = new ObjectOpenHashSet<>();
+        private final Object2IntOpenHashMap<Wire> watchedWireCounts = new Object2IntOpenHashMap<>();
+        private final Set<Wire> pendingRemovals = new ObjectOpenHashSet<>();
+    }
 
     /**
      * Needs to be called BEFORE the wire has been removed from the serverside wire multimaps
      */
     public void sendRemoveWireToWatchingPlayers(ServerLevel level, Wire wire) {
-        var players = this.getWatchingPlayers(level, wire);
+        var players = this.wireToWatchingPlayers.get(wire);
         var message = new MessageRemoveWires(Set.of(wire));
 
         for (var playerUUID : players) {
-            var player = level.getServer().getPlayerList().getPlayer(playerUUID); //this uses a map and is faster than level.getPlayerByUUID
-            Networking.sendTo(player, message);
+            var player = level.getServer().getPlayerList().getPlayer(playerUUID);
+            if (player != null) {
+                Networking.sendTo(player, message);
+            }
         }
     }
 
@@ -53,80 +58,94 @@ public class WireSync {
      * Needs to be called AFTER the wire has been added to the serverside wire multimaps
      */
     public void sendAddWireToWatchingPlayers(ServerLevel level, Wire wire) {
-        var players = this.getWatchingPlayers(level, wire);
+        var players = this.wireToWatchingPlayers.get(wire);
         var message = new MessageAddWires(Set.of(wire));
 
         for (var playerUUID : players) {
-            var player = level.getServer().getPlayerList().getPlayer(playerUUID); //this uses a map and is faster than level.getPlayerByUUID
-            Networking.sendTo(player, message);
+            var player = level.getServer().getPlayerList().getPlayer(playerUUID);
+            if (player != null) {
+                Networking.sendTo(player, message);
+            }
         }
     }
 
+    private void watchChunk(ServerPlayer player, ChunkPos chunkPos) {
+        PlayerWireState state = this.playerWireStates.computeIfAbsent(player.getUUID(), k -> new PlayerWireState());
 
-    private Set<UUID> getWatchingPlayers(ServerLevel level, Wire wire) {
-        Set<UUID> players = new ObjectOpenHashSet<>();
-        var chunks = Wires.get(level).getChunks(wire); //get all chunks the wire intersects with
-        for (var chunk : chunks) {
-            var playersInChunk = this.watchedChunkToPlayers.get(chunk); //then get the players watching each chunk
-            players.addAll(playersInChunk);
-        }
-        return players;
-    }
-
-    private void sendAddWiresInChunk(ServerPlayer player, ChunkPos chunkPos) {
-        var wires = Wires.get(player.level());
-        Networking.sendTo(player, new MessageAddWires(wires.getWires(chunkPos)));
-    }
-
-    private void sendRemoveWiresInChunk(ServerPlayer player, ChunkPos chunkPos) {
-        //tricky, we now have to make sure not to remove any wires that are still in other watched chunks
-        //luckily we have the reverse map, so we can check if a wire is still in there
-        var manager = Wires.get(player.level());
-        var wires = manager.getWires(chunkPos);
-        var wiresToRemove = new ObjectOpenHashSet<Wire>();
-        for (var wire : wires) {
-            var otherChunksForWire = manager.getChunks(wire);
-
-            //if the wire is only in one chunk we can safely remove it from the client
-            if (otherChunksForWire.size() == 1) {
-                wiresToRemove.add(wire);
-                continue;
-            }
-
-            //if not we need to check if it in any of the other watched chunks of the player
-            //if it is, we cannot remove it
-            boolean isStillWatched = false;
-            for (var otherChunk : otherChunksForWire) {
-                //the current chunk has already been removed from playerToWatchedChunk before this method was called
-                //so this will not lead to a "false positive" and we can safely just query the map.
-                if (this.playerToWatchedChunk.containsEntry(player.getUUID(), otherChunk)) {
-                    isStillWatched = true;
-                    break;
-                }
-            }
-
-            if (!isStillWatched) {
-                wiresToRemove.add(wire);
-            }
+        if (!state.watchedChunks.add(chunkPos)) {
+            return;
         }
 
-        Networking.sendTo(player, new MessageRemoveWires(wiresToRemove));
+        Set<Wire> wiresToAdd = new ObjectOpenHashSet<>();
+        for (Wire wire : Wires.get(player.level()).getWires(chunkPos)) {
+            if (state.watchedWireCounts.getInt(wire) == 0) {
+                wiresToAdd.add(wire);
+                this.wireToWatchingPlayers.put(wire, player.getUUID());
+            }
+            state.watchedWireCounts.addTo(wire, 1);
+            state.pendingRemovals.remove(wire);
+        }
+
+        if (!wiresToAdd.isEmpty()) {
+            Networking.sendTo(player, new MessageAddWires(wiresToAdd));
+        }
+    }
+
+    private void unwatchChunk(ServerPlayer player, ChunkPos chunkPos) {
+        PlayerWireState state = this.playerWireStates.get(player.getUUID());
+        if (state == null) {
+            return;
+        }
+
+        if (!state.watchedChunks.remove(chunkPos)) {
+            return;
+        }
+
+        for (Wire wire : Wires.get(player.level()).getWires(chunkPos)) {
+            int oldCount = state.watchedWireCounts.getInt(wire);
+            if (oldCount <= 1) {
+                state.watchedWireCounts.removeInt(wire);
+                state.pendingRemovals.add(wire);
+                this.wireToWatchingPlayers.remove(wire, player.getUUID());
+            } else {
+                state.watchedWireCounts.put(wire, oldCount - 1);
+            }
+        }
     }
 
     public void onChunkWatch(ChunkWatchEvent.Watch event) {
-        //TODO: probably safe to do this async
-
-        this.playerToWatchedChunk.put(event.getPlayer().getUUID(), event.getPos());
-        this.watchedChunkToPlayers.put(event.getPos(), event.getPlayer().getUUID());
-        this.sendAddWiresInChunk(event.getPlayer(), event.getPos());
-
+        this.watchChunk(event.getPlayer(), event.getPos());
     }
 
     public void onChunkUnWatch(ChunkWatchEvent.UnWatch event) {
-        //TODO: probably safe to do this async
+        this.unwatchChunk(event.getPlayer(), event.getPos());
+    }
 
-        this.playerToWatchedChunk.remove(event.getPlayer().getUUID(), event.getPos());
-        this.watchedChunkToPlayers.remove(event.getPos(), event.getPlayer().getUUID());
-        this.sendRemoveWiresInChunk(event.getPlayer(), event.getPos());
+    public void onServerTick(ServerTickEvent.Post event) {
+        for (var iterator = this.playerWireStates.entrySet().iterator(); iterator.hasNext(); ) {
+            var entry = iterator.next();
+            PlayerWireState state = entry.getValue();
+            if (state.pendingRemovals.isEmpty()) {
+                continue;
+            }
+
+            ServerPlayer player = event.getServer().getPlayerList().getPlayer(entry.getKey());
+            if (player != null) {
+                Networking.sendTo(player, new MessageRemoveWires(new ObjectOpenHashSet<>(state.pendingRemovals)));
+            }
+            state.pendingRemovals.clear();
+            if (state.watchedWireCounts.isEmpty() && state.watchedChunks.isEmpty()) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        PlayerWireState state = this.playerWireStates.remove(event.getEntity().getUUID());
+        if (state != null) {
+            for (Wire wire : state.watchedWireCounts.keySet()) {
+                this.wireToWatchingPlayers.remove(wire, event.getEntity().getUUID());
+            }
+        }
     }
 }


### PR DESCRIPTION
Forward port of #387

Should fix https://github.com/klikli-dev/theurgy/issues/378 