### PR TITLE
feat: add vats insertion blocking server config

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/config/ServerConfig.java
+++ b/src/main/java/com/klikli_dev/theurgy/config/ServerConfig.java
@@ -51,6 +51,7 @@ public class ServerConfig {
 
         protected ForgeConfigSpec.ConfigValue<List<? extends String>> sulfurSourceToBlockMappingList;
 
+        public final ForgeConfigSpec.BooleanValue vatBlocksInputOnRecipe;
         public final Lazy<Map<String, String>> sulfurSourceToBlockMapping = Lazy.of(() -> this.sulfurSourceToBlockMappingList.get().stream()
                 .map(s -> s.split(":"))
                 .collect(Collectors.toMap(s -> s[0], s -> s[1])));
@@ -66,6 +67,11 @@ public class ServerConfig {
                             "Format is: [\"source=block\", \"#sourcetag=#blocktag\", ...]"
                     )
                     .defineList("sulfurSourceToBlockMapping", List.of(), e -> ((String) e).contains("="));
+
+            this.vatBlocksInputOnRecipe = builder
+                    .comment("When set to true, digestion and fermentation vats will attempt to block item inputs if doing do would break an existing recipe.",
+                            "This is best used for any automation, ideally one that supplies all secondary inputs, and only the primary reagent is different. Note that if the container already holds a valid recipe, it will not allow input of an ingredient, even if the new ingredient will still create a valid recipe; use time-based inputs or disable this check for this scenario.")
+                            .define("vatBlocksInputOnRecipe", true);
 
             builder.pop();
         }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCraftingBehaviour.java
@@ -50,6 +50,10 @@ public class DigestionCraftingBehaviour extends CraftingBehaviour<RecipeWrapperW
         return this.recipeCachedCheck.getRecipeFor(stack, this.blockEntity.getLevel()).isPresent();
     }
 
+    public boolean hasRecipe() {
+        return this.recipeCachedCheck.getRecipeFor(this.recipeWrapperSupplier.get(), this.blockEntity.getLevel()).isPresent();
+    }
+
     @Override
     protected int getIngredientCount(DigestionRecipe recipe) {
         return 1;

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionStorageBehaviour.java
@@ -4,6 +4,8 @@
 
 package com.klikli_dev.theurgy.content.apparatus.digestionvat;
 
+import com.klikli_dev.theurgy.config.ServerConfig;
+import com.klikli_dev.theurgy.content.apparatus.fermentationvat.FermentationStorageBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.*;
 import com.klikli_dev.theurgy.content.storage.*;
 import net.minecraft.core.Direction;
@@ -164,11 +166,21 @@ public class DigestionStorageBehaviour extends StorageBehaviour<DigestionStorage
 
         @Override
         public boolean isItemValid(int slot, ItemStack stack) {
+            boolean stackAlreadyPresent = false;
+
             //we only allow one item type to fill maximum one slot, so if another slot has the stack, return false.
-            for (int i = 0; i < this.getSlots(); i++) {
-                if (i != slot && ItemHandlerHelper.canItemStacksStack(stack, this.getStackInSlot(i))) {
-                    return false;
+            for(int i = 0; i < this.getSlots(); i++){
+                if(ItemHandlerHelper.canItemStacksStack(stack,  this.getStackInSlot(i))) {
+                    if(i!=slot) {
+                        return  false;
+                    }
+                    stackAlreadyPresent = true;
                 }
+            }
+
+            // If we need a new slot, we check if there's no valid recipe currently
+            if(!stackAlreadyPresent && ServerConfig.get().recipes.vatBlocksInputOnRecipe.get() && DigestionStorageBehaviour.this.craftingBehaviour.get().hasRecipe()) {
+                return false;
             }
 
             return DigestionStorageBehaviour.this.craftingBehaviour.get().canProcess(stack) && super.isItemValid(slot, stack);

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCraftingBehaviour.java
@@ -9,6 +9,7 @@ import com.klikli_dev.theurgy.content.recipe.FermentationRecipe;
 import com.klikli_dev.theurgy.content.recipe.wrapper.RecipeWrapperWithFluid;
 import com.klikli_dev.theurgy.registry.RecipeTypeRegistry;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
@@ -48,6 +49,10 @@ public class FermentationCraftingBehaviour extends CraftingBehaviour<RecipeWrapp
 
         //now we use our custom cached check that checks only liquids:
         return this.recipeCachedCheck.getRecipeFor(stack, this.blockEntity.getLevel()).isPresent();
+    }
+
+    public boolean hasRecipe() {
+        return this.recipeCachedCheck.getRecipeFor(this.recipeWrapperSupplier.get(), this.blockEntity.getLevel()).isPresent();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationStorageBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationStorageBehaviour.java
@@ -4,7 +4,9 @@
 
 package com.klikli_dev.theurgy.content.apparatus.fermentationvat;
 
+import com.klikli_dev.theurgy.config.ServerConfig;
 import com.klikli_dev.theurgy.content.apparatus.digestionvat.DigestionCraftingBehaviour;
+import com.klikli_dev.theurgy.content.apparatus.digestionvat.DigestionStorageBehaviour;
 import com.klikli_dev.theurgy.content.behaviour.StorageBehaviour;
 import com.klikli_dev.theurgy.content.storage.*;
 import net.minecraft.core.Direction;
@@ -165,11 +167,21 @@ public class FermentationStorageBehaviour extends StorageBehaviour<FermentationS
 
         @Override
         public boolean isItemValid(int slot, ItemStack stack) {
+            boolean stackAlreadyPresent = false;
+
             //we only allow one item type to fill maximum one slot, so if another slot has the stack, return false.
             for(int i = 0; i < this.getSlots(); i++){
-                if(i != slot && ItemHandlerHelper.canItemStacksStack(stack,  this.getStackInSlot(i))){
-                    return false;
+                if(ItemHandlerHelper.canItemStacksStack(stack,  this.getStackInSlot(i))) {
+                    if(i!=slot) {
+                        return  false;
+                    }
+                    stackAlreadyPresent = true;
                 }
+            }
+
+            // If we need a new slot, we check if there's no valid recipe currently
+            if(!stackAlreadyPresent && ServerConfig.get().recipes.vatBlocksInputOnRecipe.get() && FermentationStorageBehaviour.this.craftingBehaviour.get().hasRecipe()) {
+                return false;
             }
 
             return FermentationStorageBehaviour.this.craftingBehaviour.get().canProcess(stack) && super.isItemValid(slot, stack);


### PR DESCRIPTION
Closes #383  via the 2nd method of blocking inputs.
Behaviour is visible on the attached vid: with it disabled, it behaves as is, with it enabled, it will block inputs only if the new input is attempted in a new slot ( so we will allow additional inputs of the same type ). 
This has two quirks:

- If Ingredients A and B form a recipe X, but A, B and C form a recipe Z, inserting A and B will make it impossible to insert C to form a recipe. Solution would be using time-delayed inputs on the automation side or a fix from further down.
- If A and B form recipe X, B and C form recipe Z, it is possible to insert A and then C, which would allow B to enter, but which would not form a real recipe.

This solution can be improved by making a much more expensive check, mainly:

- For first issue, we could first check if adding C will form a valid recipe. If it does, we will allow insertion, and the existing check for current recipe will be done only if this check fails
- For the second issue, instead of simply checking current recipe, we could do a much more expensive check across all recipes to see if inserting the current element will allow for creation of any valid recipe if other elements are added. So if a recipe ABC and BCD exist, we could insert BCD, CBD, CBA, but not CA(D - will fail)

Both of these solutions would require what-if checks, which if implemented as is right now would clash with the fact that the monitored inventory as it is currently does event `onXXXXXChanged` and as i'm not very familiar with forge, i don't know of a proper way to simulate inventory insertion without calling those, without making some fugly code. Just consider this an alpha implementation for consideration.

Btw sorry for the absolute dog bitrate, but apparently github requires sub 10 mb vids.
https://github.com/user-attachments/assets/8b91b753-a67e-441d-8245-9cbb95ebfe31

