### PR TITLE
refactor: use transactions for fluid storage instead of simulate flags

### DIFF
--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/digestionvat/DigestionCraftingBehaviour.java
@@ -128,7 +128,7 @@ public class DigestionCraftingBehaviour extends CraftingBehaviour<ItemHandlerWit
                 }
             }
 
-            if (FluidStorageHelper.drain(this.fluidTankSupplier.get(), pRecipe.value().getFluidAmount(), tx) < pRecipe.value().getFluidAmount()) {
+            if (FluidStorageHelper.drain(this.fluidTankSupplier.get(), pRecipe.value().getFluidAmount(), tx).getAmount() < pRecipe.value().getFluidAmount()) {
                 return false;
             }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/fermentationvat/FermentationCraftingBehaviour.java
@@ -128,7 +128,7 @@ public class FermentationCraftingBehaviour extends CraftingBehaviour<ItemHandler
                 }
             }
 
-            if (FluidStorageHelper.drain(this.fluidTankSupplier.get(), pRecipe.value().getFluidAmount(), tx) < pRecipe.value().getFluidAmount()) {
+            if (FluidStorageHelper.drain(this.fluidTankSupplier.get(), pRecipe.value().getFluidAmount(), tx).getAmount() < pRecipe.value().getFluidAmount()) {
                 return false;
             }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/liquefactioncauldron/LiquefactionCraftingBehaviour.java
@@ -59,7 +59,7 @@ public class LiquefactionCraftingBehaviour extends CraftingBehaviour<ItemHandler
             return false;
 
         //then drain the solvent
-        FluidStorageHelper.drain(this.solventTankSupplier.get(), pRecipe.value().getSolventAmount(), false);
+        FluidStorageHelper.drain(this.solventTankSupplier.get(), pRecipe.value().getSolventAmount(), null);
 
         return true;
     }

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsfluidconnector/extractor/LogisticsFluidExtractorBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/logisticsfluidconnector/extractor/LogisticsFluidExtractorBehaviour.java
@@ -20,6 +20,7 @@ import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 import org.jetbrains.annotations.Nullable;
 
 public class LogisticsFluidExtractorBehaviour extends ExtractorNodeBehaviour<ResourceHandler<FluidResource>, @Nullable Direction> {
@@ -140,25 +141,30 @@ public class LogisticsFluidExtractorBehaviour extends ExtractorNodeBehaviour<Res
         if (!extractFilter.test(this.level(), extractStack) || !insertFilter.test(this.level(), extractStack))
             return;
 
-        FluidStorageHelper.fill(insertCap, extractStack, false);
+        FluidStorageHelper.fill(insertCap, extractStack, null);
     }
 
     protected void performExtraction(ResourceHandler<FluidResource> extractCap, Filter extractFilter, ResourceHandler<FluidResource> insertCap, Filter insertFilter) {
-        //first simulate extraction, this tells us how much we can extract
-        var extractStack = FluidStorageHelper.drain(extractCap, this.extractionAmount, true);
-        if (extractStack.isEmpty())
-            return;
+        try (var tx = Transaction.openRoot()) {
+            //tentatively extract, this tells us which fluid and how much we can move
+            var extractStack = FluidStorageHelper.drain(extractCap, this.extractionAmount, tx);
+            if (extractStack.isEmpty())
+                return;
 
-        if (!extractFilter.test(this.level(), extractStack) || !insertFilter.test(this.level(), extractStack))
-            return;
+            if (!extractFilter.test(this.level(), extractStack) || !insertFilter.test(this.level(), extractStack))
+                return;
 
-        //and insertion
-        var inserted = FluidStorageHelper.fill(insertCap, extractStack, true);
+            //tentatively insert, this tells us how much actually fits into the target
+            var inserted = FluidStorageHelper.fill(insertCap, extractStack, tx);
+            if (inserted <= 0)
+                return;
 
-        //then if anything was inserted during the simulation, perform the real extraction and insertion
-        if (inserted > 0) {
-            inserted = FluidStorageHelper.fill(insertCap, extractStack, false);
-            FluidStorageHelper.drain(extractCap, inserted, false);
+            //return the part that did not fit back to the source
+            if (inserted < extractStack.getAmount()) {
+                FluidStorageHelper.fill(extractCap, extractStack.copyWithAmount(extractStack.getAmount() - inserted), tx);
+            }
+
+            tx.commit();
         }
     }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCraftingBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/apparatus/salammoniacaccumulator/SalAmmoniacAccumulatorCraftingBehaviour.java
@@ -81,7 +81,12 @@ public class SalAmmoniacAccumulatorCraftingBehaviour extends CraftingBehaviour<I
             return false;
         } else {
             var tank = this.outputTankSupplier.get();
-            int fluidAccepted = FluidStorageHelper.fill(tank, assembledStack, true);
+
+            int fluidAccepted = 0;
+            //simulate the insertion by letting the transaction roll back
+            try (var tx = Transaction.openRoot()) {
+                fluidAccepted = FluidStorageHelper.fill(tank, assembledStack, tx);
+            }
 
             //Note: Disregard the below comment, we extended the capacity of the tank to avoid this issue.
             //  the solution to void some fluid is not great because if pipes remove e.g.
@@ -103,7 +108,7 @@ public class SalAmmoniacAccumulatorCraftingBehaviour extends CraftingBehaviour<I
         var assembledFluid = pRecipe.value().assembleFluid(this.recipeInputSupplier.get(), this.blockEntity.getLevel().registryAccess());
         var outputFluidTank = this.outputTankSupplier.get();
 
-        FluidStorageHelper.fill(outputFluidTank, assembledFluid, false);
+        FluidStorageHelper.fill(outputFluidTank, assembledFluid, null);
 
         //only consume the solid solute, if the recipe requires it.
         //this avoids accidentally consuming a solute when a "water only" recipe is running while the solute is added.
@@ -117,7 +122,7 @@ public class SalAmmoniacAccumulatorCraftingBehaviour extends CraftingBehaviour<I
         }
 
         if (pRecipe.value().hasEvaporant()) {
-            FluidStorageHelper.drain(this.waterTankSupplier.get(), pRecipe.value().getEvaporantAmount(), false);
+            FluidStorageHelper.drain(this.waterTankSupplier.get(), pRecipe.value().getEvaporantAmount(), null);
         }
 
         return true;

--- a/src/main/java/com/klikli_dev/theurgy/content/behaviour/fluidhandler/OneTankFluidHandlerBehaviour.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/behaviour/fluidhandler/OneTankFluidHandlerBehaviour.java
@@ -36,11 +36,11 @@ public class OneTankFluidHandlerBehaviour implements FluidHandlerBehaviour {
 
         if (stackInHand.isEmpty() && pPlayer.isShiftKeyDown()) {
             //sneaking with empty hand means we're trying to void the liquid
-            FluidStorageHelper.drain(blockFluidHandler, Integer.MAX_VALUE, false);
+            FluidStorageHelper.drain(blockFluidHandler, Integer.MAX_VALUE, null);
             return InteractionResult.SUCCESS;
         }
 
-        if (FluidUtil.interactWithFluidHandler(pPlayer, pHand, pPos, blockFluidHandler)) {
+        if (FluidUtil.interactWithFluidHandler(pPlayer, pHand, pPos, blockFluidHandler, null)) {
             return InteractionResult.SUCCESS;
         }
 

--- a/src/main/java/com/klikli_dev/theurgy/content/storage/FluidStorageHelper.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/storage/FluidStorageHelper.java
@@ -10,6 +10,7 @@ import net.neoforged.neoforge.transfer.ResourceHandlerUtil;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.fluid.FluidUtil;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jetbrains.annotations.Nullable;
 
 public final class FluidStorageHelper {
@@ -32,68 +33,65 @@ public final class FluidStorageHelper {
         return stack.isEmpty() || handler.isValid(tank, FluidResource.of(stack));
     }
 
-    public static int fill(@Nullable ResourceHandler<FluidResource> handler, FluidStack stack, boolean simulate) {
+    /**
+     * Inserts the given stack into the handler.
+     *
+     * @param transaction The transaction context for the operation. Passing in {@code null} will open a root
+     *                    transaction that is committed at the end of this method. Passing in a transaction allows the
+     *                    caller to decide whether to commit or abort the operation, and to simulate by never committing.
+     * @return the amount that was inserted
+     */
+    public static int fill(@Nullable ResourceHandler<FluidResource> handler, FluidStack stack, @Nullable TransactionContext transaction) {
         if (handler == null || stack.isEmpty()) {
             return 0;
         }
 
-        try (var tx = Transaction.openRoot()) {
+        try (var tx = Transaction.open(transaction)) {
             int inserted = handler.insert(FluidResource.of(stack), stack.getAmount(), tx);
-            if (!simulate && inserted > 0) {
-                tx.commit();
-            }
+            tx.commit();
             return inserted;
         }
     }
 
-    public static FluidStack drain(@Nullable ResourceHandler<FluidResource> handler, FluidStack stack, boolean simulate) {
+    /**
+     * Extracts the given stack from the handler.
+     *
+     * @param transaction The transaction context for the operation. Passing in {@code null} will open a root
+     *                    transaction that is committed at the end of this method. Passing in a transaction allows the
+     *                    caller to decide whether to commit or abort the operation, and to simulate by never committing.
+     * @return the fluid that was extracted
+     */
+    public static FluidStack drain(@Nullable ResourceHandler<FluidResource> handler, FluidStack stack, @Nullable TransactionContext transaction) {
         if (handler == null || stack.isEmpty()) {
             return FluidStack.EMPTY;
         }
 
         var resource = FluidResource.of(stack);
-        try (var tx = Transaction.openRoot()) {
+        try (var tx = Transaction.open(transaction)) {
             int extracted = handler.extract(resource, stack.getAmount(), tx);
-            if (!simulate && extracted > 0) {
-                tx.commit();
+            if (extracted <= 0) {
+                return FluidStack.EMPTY;
             }
-            return extracted == 0 ? FluidStack.EMPTY : resource.toStack(extracted);
+
+            tx.commit();
+            return resource.toStack(extracted);
         }
     }
 
-    public static FluidStack drain(@Nullable ResourceHandler<FluidResource> handler, int maxDrain, boolean simulate) {
+    /**
+     * Extracts up to the given amount of the first available fluid from the handler.
+     *
+     * @param transaction The transaction context for the operation. Passing in {@code null} will open a root
+     *                    transaction that is committed at the end of this method. Passing in a transaction allows the
+     *                    caller to decide whether to commit or abort the operation, and to simulate by never committing.
+     * @return the fluid that was extracted
+     */
+    public static FluidStack drain(@Nullable ResourceHandler<FluidResource> handler, int maxDrain, @Nullable TransactionContext transaction) {
         if (handler == null || maxDrain <= 0) {
             return FluidStack.EMPTY;
         }
 
-        try (var tx = Transaction.openRoot()) {
-            var extracted = ResourceHandlerUtil.extractFirst(handler, resource -> true, maxDrain, tx);
-            if (extracted == null || extracted.amount() <= 0) {
-                return FluidStack.EMPTY;
-            }
-
-            if (!simulate) {
-                tx.commit();
-            }
-            return extracted.resource().toStack(extracted.amount());
-        }
-    }
-
-    public static int drain(@Nullable ResourceHandler<FluidResource> handler, FluidStack stack, Transaction transaction) {
-        if (handler == null || stack.isEmpty()) {
-            return 0;
-        }
-
-        return handler.extract(FluidResource.of(stack), stack.getAmount(), transaction);
-    }
-
-    public static int drain(@Nullable ResourceHandler<FluidResource> handler, int maxDrain, Transaction transaction) {
-        if (handler == null || maxDrain <= 0) {
-            return 0;
-        }
-
         var extracted = ResourceHandlerUtil.extractFirst(handler, resource -> true, maxDrain, transaction);
-        return extracted == null ? 0 : extracted.amount();
+        return extracted == null ? FluidStack.EMPTY : extracted.resource().toStack(extracted.amount());
     }
 }
-

--- a/src/main/java/com/klikli_dev/theurgy/content/storage/MonitoredFluidTank.java
+++ b/src/main/java/com/klikli_dev/theurgy/content/storage/MonitoredFluidTank.java
@@ -10,7 +10,9 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.fluid.FluidStacksResourceHandler;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
@@ -101,59 +103,47 @@ public class MonitoredFluidTank extends FluidStacksResourceHandler {
         return this.getAmountAsInt(0);
     }
 
-    public int fill(FluidStack toInsert, boolean simulate) {
-        if (!simulate) {
-            var oldStack = this.getFluid().copy();
-            var accepted = FluidStorageHelper.fill(this, toInsert, false);
-            var newStack = this.getFluid();
+    public int fill(FluidStack toInsert, @Nullable TransactionContext transaction) {
+        var oldStack = this.getFluid().copy();
+        var accepted = FluidStorageHelper.fill(this, toInsert, transaction);
+        var newStack = this.getFluid();
 
-            this.onFill(oldStack, newStack, toInsert, accepted, toInsert.getAmount() - accepted);
+        this.onFill(oldStack, newStack, toInsert, accepted, toInsert.getAmount() - accepted);
 
-            if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
-                this.onContentTypeChanged(oldStack, newStack);
-            }
-
-            return accepted;
+        if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
+            this.onContentTypeChanged(oldStack, newStack);
         }
 
-        return FluidStorageHelper.fill(this, toInsert, true);
+        return accepted;
     }
 
     //amount of fluid removed
-    public @NotNull FluidStack drain(FluidStack resource, boolean simulate) {
-        if (!simulate) {
-            var oldStack = this.getFluid().copy();
-            var extracted = FluidStorageHelper.drain(this, resource, false);
-            var newStack = this.getFluid();
+    public @NotNull FluidStack drain(FluidStack resource, @Nullable TransactionContext transaction) {
+        var oldStack = this.getFluid().copy();
+        var extracted = FluidStorageHelper.drain(this, resource, transaction);
+        var newStack = this.getFluid();
 
-            this.onDrain(oldStack, newStack, extracted);
+        this.onDrain(oldStack, newStack, extracted);
 
-            if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
-                this.onContentTypeChanged(oldStack, newStack);
-            }
-
-            return extracted;
+        if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
+            this.onContentTypeChanged(oldStack, newStack);
         }
 
-        return FluidStorageHelper.drain(this, resource, true);
+        return extracted;
     }
 
-    public @NotNull FluidStack drain(int maxDrain, boolean simulate) {
-        if (!simulate) {
-            var oldStack = this.getFluid().copy();
-            var extracted = FluidStorageHelper.drain(this, maxDrain, false);
-            var newStack = this.getFluid();
+    public @NotNull FluidStack drain(int maxDrain, @Nullable TransactionContext transaction) {
+        var oldStack = this.getFluid().copy();
+        var extracted = FluidStorageHelper.drain(this, maxDrain, transaction);
+        var newStack = this.getFluid();
 
-            this.onDrain(oldStack, newStack, extracted);
+        this.onDrain(oldStack, newStack, extracted);
 
-            if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
-                this.onContentTypeChanged(oldStack, newStack);
-            }
-
-            return extracted;
+        if (oldStack.getFluid() != newStack.getFluid() || oldStack.isEmpty() != newStack.isEmpty()) {
+            this.onContentTypeChanged(oldStack, newStack);
         }
 
-        return FluidStorageHelper.drain(this, maxDrain, true);
+        return extracted;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/klikli_dev/theurgy/gametest/DigestionVatGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/DigestionVatGameTests.java
@@ -67,7 +67,7 @@ public class DigestionVatGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(VAT_POS, DigestionVatBlockEntity.class);
             var filled = blockEntity.storageBehaviour.fluidTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
             helper.assertTrue(filled == 1000, "Fluid tank should accept 1000mb of fluid");
             helper.assertTrue(blockEntity.storageBehaviour.fluidTank.getFluidAmount() == 1000, "Fluid tank should contain 1000mb of fluid");
@@ -103,7 +103,7 @@ public class DigestionVatGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(VAT_POS, DigestionVatBlockEntity.class);
             blockEntity.storageBehaviour.inputInventory.set(0, ItemResource.of(new ItemStack(ItemRegistry.PURIFIED_GOLD.get(), 1)), 1);
-            blockEntity.storageBehaviour.fluidTank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false);
+            blockEntity.storageBehaviour.fluidTank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null);
             blockEntity.storageBehaviour.outputInventory.set(0, ItemResource.of(new ItemStack(Items.COBBLESTONE, 1)), 1);
         });
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/FermentationVatGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/FermentationVatGameTests.java
@@ -86,7 +86,7 @@ public class FermentationVatGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(VAT_POS, FermentationVatBlockEntity.class);
             var filled = blockEntity.storageBehaviour.fluidTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
 
             helper.assertTrue(filled == 1000, "Fluid tank should accept 1000mb of fluid");
@@ -133,7 +133,7 @@ public class FermentationVatGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(VAT_POS, FermentationVatBlockEntity.class);
             blockEntity.storageBehaviour.inputInventory.set(0, ItemResource.of(new ItemStack(Items.OAK_LOG, 1)), 1);
-            blockEntity.storageBehaviour.fluidTank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false);
+            blockEntity.storageBehaviour.fluidTank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null);
             blockEntity.storageBehaviour.outputInventory.set(0, ItemResource.of(new ItemStack(Items.COBBLESTONE, 1)), 1);
         });
 
@@ -161,7 +161,7 @@ public class FermentationVatGameTests {
             blockEntity.storageBehaviour.inputInventory.set(0, ItemResource.of(new ItemStack(Items.OAK_LOG, 1)), new ItemStack(Items.OAK_LOG, 1).getCount());
             // Insert fluid
             blockEntity.storageBehaviour.fluidTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
         });
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/LiquefactionCauldronGameTests.java
@@ -67,7 +67,7 @@ public class LiquefactionCauldronGameTests {
             cauldron.storageBehaviour.inputInventory.set(0, ItemResource.of(new ItemStack(Items.BONE, 1)), new ItemStack(Items.BONE, 1).getCount());
             // Insert solvent fluid (sal ammoniac, plenty for the recipe)
             cauldron.storageBehaviour.solventTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
         });
     }
@@ -198,7 +198,7 @@ public class LiquefactionCauldronGameTests {
         helper.runAfterDelay(1, () -> {
             var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
             var filled = cauldron.storageBehaviour.solventTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 500), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 500), null
             );
 
             helper.assertTrue(
@@ -223,7 +223,7 @@ public class LiquefactionCauldronGameTests {
         helper.runAfterDelay(1, () -> {
             var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
             cauldron.storageBehaviour.solventTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
             helper.assertTrue(
                     cauldron.storageBehaviour.solventTank.getFluidAmount() == 1000,
@@ -380,7 +380,7 @@ public class LiquefactionCauldronGameTests {
         helper.runAfterDelay(2, () -> {
             var cauldron = helper.getBlockEntity(CAULDRON_LOWER_POS, LiquefactionCauldronBlockEntity.class);
             cauldron.storageBehaviour.solventTank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
         });
 

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacAccumulatorGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacAccumulatorGameTests.java
@@ -51,7 +51,7 @@ public class SalAmmoniacAccumulatorGameTests {
             var blockEntity = helper.getBlockEntity(ACCUMULATOR_POS, SalAmmoniacAccumulatorBlockEntity.class);
             var filled = blockEntity.waterTank.fill(
                     new FluidStack(Fluids.WATER, 1000),
-                    false
+                    null
             );
             helper.assertTrue(filled == 1000, "Water tank should accept 1000mb of water");
             helper.assertTrue(blockEntity.waterTank.getFluidAmount() == 1000, "Water tank should contain 1000mb of water");

--- a/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacTankGameTests.java
+++ b/src/main/java/com/klikli_dev/theurgy/gametest/SalAmmoniacTankGameTests.java
@@ -31,7 +31,7 @@ public class SalAmmoniacTankGameTests {
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(TANK_POS, SalAmmoniacTankBlockEntity.class);
             var filled = blockEntity.tank.fill(
-                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false
+                    new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null
             );
             helper.assertTrue(filled > 0, "Tank should accept sal ammoniac fluid");
             helper.assertTrue(blockEntity.tank.getFluidAmount() == 1000, "Tank should contain 1000mb");
@@ -44,12 +44,12 @@ public class SalAmmoniacTankGameTests {
 
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(TANK_POS, SalAmmoniacTankBlockEntity.class);
-            blockEntity.tank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), false);
+            blockEntity.tank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1000), null);
         });
 
         helper.runAfterDelay(2, () -> {
             var blockEntity = helper.getBlockEntity(TANK_POS, SalAmmoniacTankBlockEntity.class);
-            var drained = blockEntity.tank.drain(500, false);
+            var drained = blockEntity.tank.drain(500, null);
             helper.assertTrue(drained.getAmount() == 500, "Should drain 500mb");
             helper.assertTrue(blockEntity.tank.getFluidAmount() == 500, "Tank should have 500mb remaining");
             helper.succeed();
@@ -61,7 +61,7 @@ public class SalAmmoniacTankGameTests {
 
         helper.runAfterDelay(1, () -> {
             var blockEntity = helper.getBlockEntity(TANK_POS, SalAmmoniacTankBlockEntity.class);
-            blockEntity.tank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1500), false);
+            blockEntity.tank.fill(new FluidStack(FluidRegistry.SAL_AMMONIAC.get(), 1500), null);
             helper.assertTrue(blockEntity.tank.getFluidAmount() == 1500, "Tank should contain 1500mb");
             helper.succeed();
         });


### PR DESCRIPTION
## Summary

- Replace the deprecated oolean simulate parameter on FluidStorageHelper ill/drain methods with a nullable TransactionContext, following the NeoForge resource handler transaction paradigm. Passing 
ull opens and commits a root transaction; passing an open transaction lets the caller decide whether to commit (real) or abort (simulate).
- Update MonitoredFluidTank ill/drain to take a TransactionContext instead of a simulate flag.
- Collapse LogisticsFluidExtractorBehaviour.performExtraction into a single transaction, rolling back automatically instead of manual simulate/commit steps.
- Update all call sites (crafting behaviours and game tests) and the deprecated type-separated overloads.
- Replace the deprecated FluidUtil.interactWithFluidHandler(player, hand, pos, handler) with the transaction-aware overload in OneTankFluidHandlerBehaviour.

## Verification

- .\gradlew.bat compileJava succeeds.
- .\gradlew.bat runGameTestServer passes all 148 tests.